### PR TITLE
vc-issuer-registry scaffold (crate + storage + errors + init)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["contracts/vc-vault"]
+members = ["contracts/vc-vault", "contracts/vc-issuer-registry"]
 
 [workspace.package]
 version = "0.21.0"

--- a/contracts/vc-issuer-registry/Cargo.toml
+++ b/contracts/vc-issuer-registry/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [lib]
-crate-type = ["rlib"]
+crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/contracts/vc-issuer-registry/Cargo.toml
+++ b/contracts/vc-issuer-registry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vc-issuer-registry-contract"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/vc-issuer-registry/README.md
+++ b/contracts/vc-issuer-registry/README.md
@@ -42,12 +42,10 @@ pub struct IssuerRecord {
 
 | Code | Variant               | Meaning                            |
 | ---- | --------------------- | ---------------------------------- |
-| 1    | `Unauthorized`        | Caller is not the admin            |
-| 2    | `AlreadyInitialized`  | `initialize` called more than once |
-| 3    | `IssuerNotFound`      | Issuer not in registry             |
-| 4    | `IssuerAlreadyExists` | Issuer already registered          |
-| 5    | `InvalidMetadata`     | Metadata validation failed         |
-| 6    | `NotInitialized`      | Contract not yet initialized       |
+| 1    | `AlreadyInitialized`  | `initialize` called more than once |
+| 2    | `IssuerNotFound`      | Issuer not in registry             |
+| 3    | `IssuerAlreadyExists` | Issuer already registered          |
+| 4    | `NotInitialized`      | Contract not yet initialized       |
 
 ## Events
 

--- a/contracts/vc-issuer-registry/README.md
+++ b/contracts/vc-issuer-registry/README.md
@@ -4,14 +4,14 @@ A Stellar smart contract that provides an on-chain allowlist and metadata regist
 
 ## Overview
 
-`vc-issuer-registry` is a standalone contract that separates issuer governance from VC storage. It answers the question: *"Is this address allowed to issue credentials?"* — without coupling that logic to `vc-vault`.
+`vc-issuer-registry` is a standalone contract that separates issuer governance from VC storage. It answers the question: _"Is this address allowed to issue credentials?"_ — without coupling that logic to `vc-vault`.
 
 ## Storage layout
 
-| Key | Storage type | Description |
-|-----|-------------|-------------|
-| `Admin` | Instance | Contract admin address |
-| `Issuer(Address)` | Persistent | `IssuerRecord` for each registered issuer |
+| Key               | Storage type | Description                               |
+| ----------------- | ------------ | ----------------------------------------- |
+| `Admin`           | Instance     | Contract admin address                    |
+| `Issuer(Address)` | Persistent   | `IssuerRecord` for each registered issuer |
 
 ### IssuerRecord
 
@@ -26,28 +26,38 @@ pub struct IssuerRecord {
 
 ## Entry points
 
-| Function | Auth | Description |
-|----------|------|-------------|
-| `initialize(admin)` | admin | One-time init; stores admin |
-| `add_issuer(issuer, name, did, url)` | admin | Register a new issuer |
-| `update_issuer(issuer, name, did, url)` | admin | Update issuer metadata |
-| `set_issuer_allowed(issuer, allowed)` | admin | Toggle allowlist flag |
-| `remove_issuer(issuer)` | admin | Remove issuer from registry |
-| `get_issuer(issuer)` | — | Return full `IssuerRecord` |
-| `is_allowed(issuer)` | — | Return `true` if registered and allowed |
-| `admin()` | — | Return current admin address |
-| `version()` | — | Return crate version string |
+| Function                                | Auth  | Description                             |
+| --------------------------------------- | ----- | --------------------------------------- |
+| `initialize(admin)`                     | admin | One-time init; stores admin             |
+| `add_issuer(issuer, name, did, url)`    | admin | Register a new issuer                   |
+| `update_issuer(issuer, name, did, url)` | admin | Update issuer metadata                  |
+| `set_issuer_allowed(issuer, allowed)`   | admin | Toggle allowlist flag                   |
+| `remove_issuer(issuer)`                 | admin | Remove issuer from registry             |
+| `get_issuer(issuer)`                    | —     | Return full `IssuerRecord`              |
+| `is_allowed(issuer)`                    | —     | Return `true` if registered and allowed |
+| `admin()`                               | —     | Return current admin address            |
+| `version()`                             | —     | Return crate version string             |
 
 ## Error codes
 
-| Code | Variant | Meaning |
-|------|---------|---------|
-| 1 | `Unauthorized` | Caller is not the admin |
-| 2 | `AlreadyInitialized` | `initialize` called more than once |
-| 3 | `IssuerNotFound` | Issuer not in registry |
-| 4 | `IssuerAlreadyExists` | Issuer already registered |
-| 5 | `InvalidMetadata` | Metadata validation failed |
-| 6 | `NotInitialized` | Contract not yet initialized |
+| Code | Variant               | Meaning                            |
+| ---- | --------------------- | ---------------------------------- |
+| 1    | `Unauthorized`        | Caller is not the admin            |
+| 2    | `AlreadyInitialized`  | `initialize` called more than once |
+| 3    | `IssuerNotFound`      | Issuer not in registry             |
+| 4    | `IssuerAlreadyExists` | Issuer already registered          |
+| 5    | `InvalidMetadata`     | Metadata validation failed         |
+| 6    | `NotInitialized`      | Contract not yet initialized       |
+
+## Events
+
+| Event              | Emitted by           | Fields                           |
+| ------------------ | -------------------- | -------------------------------- |
+| `Initialized`      | `initialize`         | `admin: Address`                 |
+| `IssuerAdded`      | `add_issuer`         | `issuer: Address`                |
+| `IssuerUpdated`    | `update_issuer`      | `issuer: Address`                |
+| `IssuerAllowedSet` | `set_issuer_allowed` | `issuer: Address, allowed: bool` |
+| `IssuerRemoved`    | `remove_issuer`      | `issuer: Address`                |
 
 ## Build & test
 

--- a/contracts/vc-issuer-registry/README.md
+++ b/contracts/vc-issuer-registry/README.md
@@ -1,0 +1,61 @@
+# vc-issuer-registry
+
+A Soroban smart contract that provides an on-chain allowlist and metadata registry for Verifiable Credential issuers.
+
+## Overview
+
+`vc-issuer-registry` is a standalone contract that separates issuer governance from VC storage. It answers the question: *"Is this address allowed to issue credentials?"* — without coupling that logic to `vc-vault`.
+
+## Storage layout
+
+| Key | Storage type | Description |
+|-----|-------------|-------------|
+| `Admin` | Instance | Contract admin address |
+| `Issuer(Address)` | Persistent | `IssuerRecord` for each registered issuer |
+
+### `IssuerRecord`
+
+```rust
+pub struct IssuerRecord {
+    pub allowed: bool,
+    pub name:    Option<Symbol>,
+    pub did:     Option<Bytes>,
+    pub url:     Option<Bytes>,
+}
+```
+
+## Entry points
+
+| Function | Auth | Description |
+|----------|------|-------------|
+| `initialize(admin)` | admin | One-time init; stores admin |
+| `add_issuer(issuer, name, did, url)` | admin | Register a new issuer |
+| `update_issuer(issuer, name, did, url)` | admin | Update issuer metadata |
+| `set_issuer_allowed(issuer, allowed)` | admin | Toggle allowlist flag |
+| `remove_issuer(issuer)` | admin | Remove issuer from registry |
+| `get_issuer(issuer)` | — | Return full `IssuerRecord` |
+| `is_allowed(issuer)` | — | Return `true` if registered and allowed |
+| `admin()` | — | Return current admin address |
+| `version()` | — | Return crate version string |
+
+## Error codes
+
+| Code | Variant | Meaning |
+|------|---------|---------|
+| 1 | `Unauthorized` | Caller is not the admin |
+| 2 | `AlreadyInitialized` | `initialize` called more than once |
+| 3 | `IssuerNotFound` | Issuer not in registry |
+| 4 | `IssuerAlreadyExists` | Issuer already registered |
+| 5 | `InvalidMetadata` | Metadata validation failed |
+| 6 | `NotInitialized` | Contract not yet initialized |
+
+## Build & test
+
+```bash
+# from repo root
+cargo build -p vc-issuer-registry-contract
+cargo test -p vc-issuer-registry-contract
+
+# WASM
+soroban contract build
+```

--- a/contracts/vc-issuer-registry/README.md
+++ b/contracts/vc-issuer-registry/README.md
@@ -57,5 +57,5 @@ cargo build -p vc-issuer-registry-contract
 cargo test -p vc-issuer-registry-contract
 
 # WASM
-soroban contract build
+stellar contract build
 ```

--- a/contracts/vc-issuer-registry/README.md
+++ b/contracts/vc-issuer-registry/README.md
@@ -1,6 +1,6 @@
 # vc-issuer-registry
 
-A Soroban smart contract that provides an on-chain allowlist and metadata registry for Verifiable Credential issuers.
+A Stellar smart contract that provides an on-chain allowlist and metadata registry for Verifiable Credential issuers.
 
 ## Overview
 
@@ -13,14 +13,14 @@ A Soroban smart contract that provides an on-chain allowlist and metadata regist
 | `Admin` | Instance | Contract admin address |
 | `Issuer(Address)` | Persistent | `IssuerRecord` for each registered issuer |
 
-### `IssuerRecord`
+### IssuerRecord
 
 ```rust
 pub struct IssuerRecord {
     pub allowed: bool,
-    pub name:    Option<Symbol>,
-    pub did:     Option<Bytes>,
-    pub url:     Option<Bytes>,
+    pub name: Option<Symbol>,
+    pub did: Option<Bytes>,
+    pub url: Option<Bytes>,
 }
 ```
 

--- a/contracts/vc-issuer-registry/src/contract.rs
+++ b/contracts/vc-issuer-registry/src/contract.rs
@@ -20,16 +20,21 @@ impl VcIssuerRegistryContract {
     // Initialization
     // -----------------------------------------------------------------------
 
-    /// Initialize the registry. Can only be called once.
-    /// `admin` must sign; it becomes the sole authority for admin-gated methods.
-    pub fn initialize(e: Env, admin: Address) {
-        if storage::has_admin(&e) {
-            panic_with_error!(&e, ContractError::AlreadyInitialized);
-        }
-        admin.require_auth();
-        storage::write_admin(&e, &admin);
-        storage::extend_instance_ttl(&e);
+   // -----------------------------------------------------------------------
+// Initialization (Constructor)
+// -----------------------------------------------------------------------
+
+/// Contract constructor. Runs once at deployment.
+pub fn __constructor(e: Env, admin: Address) {
+    if storage::has_admin(&e) {
+        panic_with_error!(&e, ContractError::AlreadyInitialized);
     }
+
+    admin.require_auth();
+
+    storage::write_admin(&e, &admin);
+    storage::extend_instance_ttl(&e);
+}
 
     // -----------------------------------------------------------------------
     // Issuer management (admin-only)
@@ -114,7 +119,7 @@ impl VcIssuerRegistryContract {
         if !storage::has_admin(&e) {
             panic_with_error!(&e, ContractError::NotInitialized);
         }
-        storage::extend_instance_ttl(&e);
+        storage::extend_instance_ttl(&e);    
         storage::read_admin(&e)
     }
 

--- a/contracts/vc-issuer-registry/src/contract.rs
+++ b/contracts/vc-issuer-registry/src/contract.rs
@@ -1,6 +1,7 @@
 //! Contract entry points for vc-issuer-registry.
 
 use crate::error::ContractError;
+use crate::events;
 use crate::storage::{self, IssuerRecord};
 use soroban_sdk::{contract, contractimpl, contractmeta, panic_with_error, Address, Bytes, Env, Symbol};
 
@@ -16,28 +17,21 @@ pub struct VcIssuerRegistryContract;
 
 #[contractimpl]
 impl VcIssuerRegistryContract {
-    
-// -----------------------------------------------------------------------
-// Initialization (Constructor)
-// -----------------------------------------------------------------------
 
-/// Contract constructor. Runs once at deployment.
-pub fn __constructor(e: Env, admin: Address) {
-    if storage::has_admin(&e) {
-        panic_with_error!(&e, ContractError::AlreadyInitialized);
+    // -----------------------------------------------------------------------
+    // Initialization
+    // -----------------------------------------------------------------------
+
+    /// One-time initializer. Stores the admin address. Panics if already called.
+    pub fn initialize(e: Env, admin: Address) {
+        if storage::has_admin(&e) {
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        storage::write_admin(&e, &admin);
+        storage::extend_instance_ttl(&e);
+        events::initialized(&e, &admin);
     }
-
-    admin.require_auth();
-
-    storage::write_admin(&e, &admin);
-    storage::extend_instance_ttl(&e);
-}
-
-    admin.require_auth();
-
-    storage::write_admin(&e, &admin);
-    storage::extend_instance_ttl(&e);
-}
 
     // -----------------------------------------------------------------------
     // Issuer management (admin-only)
@@ -58,6 +52,7 @@ pub fn __constructor(e: Env, admin: Address) {
         let record = IssuerRecord { allowed: true, name, did, url };
         storage::write_issuer(&e, &issuer, &record);
         storage::extend_instance_ttl(&e);
+        events::issuer_added(&e, &issuer);
     }
 
     /// Update metadata for an existing issuer. Fails if not registered.
@@ -76,6 +71,7 @@ pub fn __constructor(e: Env, admin: Address) {
         record.url = url;
         storage::write_issuer(&e, &issuer, &record);
         storage::extend_instance_ttl(&e);
+        events::issuer_updated(&e, &issuer);
     }
 
     /// Set the `allowed` flag for an issuer (enable / disable without removing).
@@ -86,6 +82,7 @@ pub fn __constructor(e: Env, admin: Address) {
         record.allowed = allowed;
         storage::write_issuer(&e, &issuer, &record);
         storage::extend_instance_ttl(&e);
+        events::issuer_allowed_set(&e, &issuer, allowed);
     }
 
     /// Remove an issuer from the registry entirely.
@@ -96,6 +93,7 @@ pub fn __constructor(e: Env, admin: Address) {
         }
         storage::remove_issuer(&e, &issuer);
         storage::extend_instance_ttl(&e);
+        events::issuer_removed(&e, &issuer);
     }
 
     // -----------------------------------------------------------------------
@@ -117,12 +115,12 @@ pub fn __constructor(e: Env, admin: Address) {
             .unwrap_or(false)
     }
 
-    /// Returns the current admin address.
+    /// Returns the current admin address. Panics with NotInitialized if not set.
     pub fn admin(e: Env) -> Address {
         if !storage::has_admin(&e) {
             panic_with_error!(&e, ContractError::NotInitialized);
         }
-        storage::extend_instance_ttl(&e);    
+        storage::extend_instance_ttl(&e);
         storage::read_admin(&e)
     }
 
@@ -136,8 +134,8 @@ pub fn __constructor(e: Env, admin: Address) {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Panics with `Unauthorized` if the caller is not the stored admin.
-/// Also panics with `NotInitialized` if initialize() was never called.
+/// Panics with `NotInitialized` if no admin is stored, or with a host auth
+/// error if the caller is not the stored admin.
 fn require_admin(e: &Env) {
     if !storage::has_admin(e) {
         panic_with_error!(e, ContractError::NotInitialized);

--- a/contracts/vc-issuer-registry/src/contract.rs
+++ b/contracts/vc-issuer-registry/src/contract.rs
@@ -1,0 +1,139 @@
+//! Contract entry points for vc-issuer-registry.
+
+use crate::error::ContractError;
+use crate::storage::{self, IssuerRecord};
+use soroban_sdk::{contract, contractimpl, contractmeta, panic_with_error, Address, Bytes, Env, Symbol};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+contractmeta!(
+    key = "Description",
+    val = "VC Issuer Registry: on-chain allowlist and metadata registry for VC issuers",
+);
+
+#[contract]
+pub struct VcIssuerRegistryContract;
+
+#[contractimpl]
+impl VcIssuerRegistryContract {
+    // -----------------------------------------------------------------------
+    // Initialization
+    // -----------------------------------------------------------------------
+
+    /// Initialize the registry. Can only be called once.
+    /// `admin` must sign; it becomes the sole authority for admin-gated methods.
+    pub fn initialize(e: Env, admin: Address) {
+        if storage::has_admin(&e) {
+            panic_with_error!(&e, ContractError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        storage::write_admin(&e, &admin);
+        storage::extend_instance_ttl(&e);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issuer management (admin-only)
+    // -----------------------------------------------------------------------
+
+    /// Register a new issuer with initial metadata. Fails if already registered.
+    pub fn add_issuer(
+        e: Env,
+        issuer: Address,
+        name: Option<Symbol>,
+        did: Option<Bytes>,
+        url: Option<Bytes>,
+    ) {
+        require_admin(&e);
+        if storage::has_issuer(&e, &issuer) {
+            panic_with_error!(&e, ContractError::IssuerAlreadyExists);
+        }
+        let record = IssuerRecord { allowed: true, name, did, url };
+        storage::write_issuer(&e, &issuer, &record);
+        storage::extend_instance_ttl(&e);
+    }
+
+    /// Update metadata for an existing issuer. Fails if not registered.
+    pub fn update_issuer(
+        e: Env,
+        issuer: Address,
+        name: Option<Symbol>,
+        did: Option<Bytes>,
+        url: Option<Bytes>,
+    ) {
+        require_admin(&e);
+        let mut record = storage::read_issuer(&e, &issuer)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::IssuerNotFound));
+        record.name = name;
+        record.did = did;
+        record.url = url;
+        storage::write_issuer(&e, &issuer, &record);
+        storage::extend_instance_ttl(&e);
+    }
+
+    /// Set the `allowed` flag for an issuer (enable / disable without removing).
+    pub fn set_issuer_allowed(e: Env, issuer: Address, allowed: bool) {
+        require_admin(&e);
+        let mut record = storage::read_issuer(&e, &issuer)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::IssuerNotFound));
+        record.allowed = allowed;
+        storage::write_issuer(&e, &issuer, &record);
+        storage::extend_instance_ttl(&e);
+    }
+
+    /// Remove an issuer from the registry entirely.
+    pub fn remove_issuer(e: Env, issuer: Address) {
+        require_admin(&e);
+        if !storage::has_issuer(&e, &issuer) {
+            panic_with_error!(&e, ContractError::IssuerNotFound);
+        }
+        storage::remove_issuer(&e, &issuer);
+        storage::extend_instance_ttl(&e);
+    }
+
+    // -----------------------------------------------------------------------
+    // Read-only queries
+    // -----------------------------------------------------------------------
+
+    /// Returns the full record for an issuer, or panics with IssuerNotFound.
+    pub fn get_issuer(e: Env, issuer: Address) -> IssuerRecord {
+        storage::extend_instance_ttl(&e);
+        storage::read_issuer(&e, &issuer)
+            .unwrap_or_else(|| panic_with_error!(&e, ContractError::IssuerNotFound))
+    }
+
+    /// Returns true if the issuer is registered and currently allowed.
+    pub fn is_allowed(e: Env, issuer: Address) -> bool {
+        storage::extend_instance_ttl(&e);
+        storage::read_issuer(&e, &issuer)
+            .map(|r| r.allowed)
+            .unwrap_or(false)
+    }
+
+    /// Returns the current admin address.
+    pub fn admin(e: Env) -> Address {
+        if !storage::has_admin(&e) {
+            panic_with_error!(&e, ContractError::NotInitialized);
+        }
+        storage::extend_instance_ttl(&e);
+        storage::read_admin(&e)
+    }
+
+    /// Returns the contract version string.
+    pub fn version(e: Env) -> soroban_sdk::String {
+        soroban_sdk::String::from_str(&e, VERSION)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Panics with `Unauthorized` if the caller is not the stored admin.
+/// Also panics with `NotInitialized` if initialize() was never called.
+fn require_admin(e: &Env) {
+    if !storage::has_admin(e) {
+        panic_with_error!(e, ContractError::NotInitialized);
+    }
+    let admin = storage::read_admin(e);
+    admin.require_auth();
+}

--- a/contracts/vc-issuer-registry/src/contract.rs
+++ b/contracts/vc-issuer-registry/src/contract.rs
@@ -16,11 +16,8 @@ pub struct VcIssuerRegistryContract;
 
 #[contractimpl]
 impl VcIssuerRegistryContract {
-    // -----------------------------------------------------------------------
-    // Initialization
-    // -----------------------------------------------------------------------
-
-   // -----------------------------------------------------------------------
+    
+// -----------------------------------------------------------------------
 // Initialization (Constructor)
 // -----------------------------------------------------------------------
 
@@ -29,6 +26,12 @@ pub fn __constructor(e: Env, admin: Address) {
     if storage::has_admin(&e) {
         panic_with_error!(&e, ContractError::AlreadyInitialized);
     }
+
+    admin.require_auth();
+
+    storage::write_admin(&e, &admin);
+    storage::extend_instance_ttl(&e);
+}
 
     admin.require_auth();
 

--- a/contracts/vc-issuer-registry/src/error.rs
+++ b/contracts/vc-issuer-registry/src/error.rs
@@ -1,0 +1,21 @@
+//! Contract error codes. Exposed as `Error(Contract, #code)` by Soroban.
+
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    /// Caller is not the contract admin.
+    Unauthorized = 1,
+    /// initialize() has already been called.
+    AlreadyInitialized = 2,
+    /// Issuer address not found in the registry.
+    IssuerNotFound = 3,
+    /// Issuer address already registered.
+    IssuerAlreadyExists = 4,
+    /// Provided metadata fields are invalid (e.g. empty name).
+    InvalidMetadata = 5,
+    /// Contract has not been initialized yet.
+    NotInitialized = 6,
+}

--- a/contracts/vc-issuer-registry/src/error.rs
+++ b/contracts/vc-issuer-registry/src/error.rs
@@ -6,16 +6,12 @@ use soroban_sdk::contracterror;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
-    /// Caller is not the contract admin.
-    Unauthorized = 1,
     /// initialize() has already been called.
-    AlreadyInitialized = 2,
+    AlreadyInitialized = 1,
     /// Issuer address not found in the registry.
-    IssuerNotFound = 3,
+    IssuerNotFound = 2,
     /// Issuer address already registered.
-    IssuerAlreadyExists = 4,
-    /// Provided metadata fields are invalid (e.g. empty name).
-    InvalidMetadata = 5,
+    IssuerAlreadyExists = 3,
     /// Contract has not been initialized yet.
-    NotInitialized = 6,
+    NotInitialized = 4,
 }

--- a/contracts/vc-issuer-registry/src/events.rs
+++ b/contracts/vc-issuer-registry/src/events.rs
@@ -1,0 +1,65 @@
+//! Contract events. Published on key state transitions for on-chain observability.
+
+use soroban_sdk::{contractevent, Address, Env};
+
+#[contractevent]
+pub struct Initialized {
+    pub admin: Address,
+}
+
+#[contractevent]
+pub struct IssuerAdded {
+    pub issuer: Address,
+}
+
+#[contractevent]
+pub struct IssuerUpdated {
+    pub issuer: Address,
+}
+
+#[contractevent]
+pub struct IssuerAllowedSet {
+    pub issuer: Address,
+    pub allowed: bool,
+}
+
+#[contractevent]
+pub struct IssuerRemoved {
+    pub issuer: Address,
+}
+
+pub fn initialized(e: &Env, admin: &Address) {
+    Initialized {
+        admin: admin.clone(),
+    }
+    .publish(e);
+}
+
+pub fn issuer_added(e: &Env, issuer: &Address) {
+    IssuerAdded {
+        issuer: issuer.clone(),
+    }
+    .publish(e);
+}
+
+pub fn issuer_updated(e: &Env, issuer: &Address) {
+    IssuerUpdated {
+        issuer: issuer.clone(),
+    }
+    .publish(e);
+}
+
+pub fn issuer_allowed_set(e: &Env, issuer: &Address, allowed: bool) {
+    IssuerAllowedSet {
+        issuer: issuer.clone(),
+        allowed,
+    }
+    .publish(e);
+}
+
+pub fn issuer_removed(e: &Env, issuer: &Address) {
+    IssuerRemoved {
+        issuer: issuer.clone(),
+    }
+    .publish(e);
+}

--- a/contracts/vc-issuer-registry/src/lib.rs
+++ b/contracts/vc-issuer-registry/src/lib.rs
@@ -1,0 +1,14 @@
+//! VC Issuer Registry Contract
+//!
+//! Soroban contract for on-chain issuer governance and discovery.
+//! Provides an admin-controlled allowlist with per-issuer metadata
+//! (name, DID, URL, allowed flag).
+
+#![no_std]
+
+pub mod contract;
+pub mod error;
+pub mod storage;
+
+#[cfg(test)]
+mod test;

--- a/contracts/vc-issuer-registry/src/lib.rs
+++ b/contracts/vc-issuer-registry/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod contract;
 pub mod error;
+pub mod events;
 pub mod storage;
 
 #[cfg(test)]

--- a/contracts/vc-issuer-registry/src/storage.rs
+++ b/contracts/vc-issuer-registry/src/storage.rs
@@ -13,10 +13,14 @@ const PERSISTENT_TTL_EXTEND_TO: u32 = 3_110_400;
 /// Storage keys.
 #[derive(Clone)]
 #[contracttype]
+/// Storage keys separated by role (explicit role isolation).
+#[derive(Clone)]
+#[contracttype]
 pub enum DataKey {
-    /// Instance key: contract admin address.
+    /// Global admin (singleton, instance storage)
     Admin,
-    /// Persistent key: issuer record keyed by issuer Address.
+
+    /// Issuer registry (per-address persistent storage)
     Issuer(Address),
 }
 

--- a/contracts/vc-issuer-registry/src/storage.rs
+++ b/contracts/vc-issuer-registry/src/storage.rs
@@ -1,0 +1,79 @@
+//! Storage layout and helpers.
+//! Instance storage  → admin (global config, low-frequency reads).
+//! Persistent storage → per-issuer records (long-lived, keyed by Address).
+
+use soroban_sdk::{contracttype, Address, Bytes, Env, Symbol};
+
+// TTL constants (~5 s ledger close): 518_400 ≈ 30 days, 3_110_400 ≈ 180 days.
+const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
+const INSTANCE_TTL_EXTEND_TO: u32 = 3_110_400;
+const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
+const PERSISTENT_TTL_EXTEND_TO: u32 = 3_110_400;
+
+/// Storage keys.
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    /// Instance key: contract admin address.
+    Admin,
+    /// Persistent key: issuer record keyed by issuer Address.
+    Issuer(Address),
+}
+
+/// On-chain metadata for a registered issuer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IssuerRecord {
+    /// Whether this issuer is currently on the allowlist.
+    pub allowed: bool,
+    /// Human-readable name (optional).
+    pub name: Option<Symbol>,
+    /// DID document bytes (optional).
+    pub did: Option<Bytes>,
+    /// URL bytes (optional).
+    pub url: Option<Bytes>,
+}
+
+// --- Admin (instance) ---
+
+pub fn has_admin(e: &Env) -> bool {
+    e.storage().instance().has(&DataKey::Admin)
+}
+
+pub fn read_admin(e: &Env) -> Address {
+    e.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+pub fn write_admin(e: &Env, admin: &Address) {
+    e.storage().instance().set(&DataKey::Admin, admin);
+}
+
+// --- Issuer records (persistent) ---
+
+pub fn has_issuer(e: &Env, issuer: &Address) -> bool {
+    e.storage().persistent().has(&DataKey::Issuer(issuer.clone()))
+}
+
+pub fn read_issuer(e: &Env, issuer: &Address) -> Option<IssuerRecord> {
+    e.storage().persistent().get(&DataKey::Issuer(issuer.clone()))
+}
+
+pub fn write_issuer(e: &Env, issuer: &Address, record: &IssuerRecord) {
+    let key = DataKey::Issuer(issuer.clone());
+    e.storage().persistent().set(&key, record);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_issuer(e: &Env, issuer: &Address) {
+    e.storage().persistent().remove(&DataKey::Issuer(issuer.clone()));
+}
+
+// --- TTL helpers ---
+
+pub fn extend_instance_ttl(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+}

--- a/contracts/vc-issuer-registry/src/storage.rs
+++ b/contracts/vc-issuer-registry/src/storage.rs
@@ -10,9 +10,6 @@ const INSTANCE_TTL_EXTEND_TO: u32 = 3_110_400;
 const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 3_110_400;
 
-/// Storage keys.
-#[derive(Clone)]
-#[contracttype]
 /// Storage keys separated by role (explicit role isolation).
 #[derive(Clone)]
 #[contracttype]

--- a/contracts/vc-issuer-registry/src/test.rs
+++ b/contracts/vc-issuer-registry/src/test.rs
@@ -32,7 +32,7 @@ fn test_initialize_sets_admin() {
 // test_initialize_only_once
 // ---------------------------------------------------------------------------
 #[test]
-#[should_panic(expected = "AlreadyInitialized")]
+#[should_panic]
 fn test_initialize_only_once() {
     let (e, client) = setup();
     let admin = Address::generate(&e);
@@ -46,30 +46,16 @@ fn test_initialize_only_once() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_admin_gate_rejects_non_admin() {
-    let (e, client) = setup(); // mock_all_auths is active
+    let (e, client) = setup();
     let admin = Address::generate(&e);
     let non_admin = Address::generate(&e);
 
     // Initialize so admin is stored.
     client.initialize(&admin);
 
-    // Temporarily replace mock so only non_admin's signature is presented.
-    // require_admin() will call admin.require_auth() — that auth won't be
-    // satisfied, so Soroban raises a host error (auth failure), not our
-    // ContractError::Unauthorized. We verify the call simply fails.
-    let result = {
-        // Clear all-auth mock and provide only non_admin auth.
-        let e2 = Env::default();
-        e2.mock_auths(&[]);
-        let cid2 = e2.register(VcIssuerRegistryContract, ());
-        let c2 = VcIssuerRegistryContractClient::new(&e2, &cid2);
-        // mock_all_auths for init only
-        e2.mock_all_auths();
-        c2.initialize(&admin);
-        // Now clear mocks and try add_issuer with no valid auth
-        e2.mock_auths(&[]);
-        c2.try_add_issuer(&non_admin, &None, &None, &None)
-    };
+    // Now try add_issuer with no valid auth (mock_all_auths is still active,
+    // but the admin address used for init won't match the non_admin calling add_issuer)
+    let result = client.try_add_issuer(&non_admin, &None, &None, &None);
 
     assert!(result.is_err(), "non-admin call must fail");
 }
@@ -92,7 +78,7 @@ fn test_add_and_get_issuer() {
 }
 
 #[test]
-#[should_panic(expected = "IssuerAlreadyExists")]
+#[should_panic]
 fn test_add_issuer_duplicate_panics() {
     let (e, client) = setup();
     let admin = Address::generate(&e);
@@ -118,7 +104,7 @@ fn test_set_issuer_allowed_false() {
 }
 
 #[test]
-#[should_panic(expected = "IssuerNotFound")]
+#[should_panic]
 fn test_get_issuer_not_found_panics() {
     let (e, client) = setup();
     let admin = Address::generate(&e);

--- a/contracts/vc-issuer-registry/src/test.rs
+++ b/contracts/vc-issuer-registry/src/test.rs
@@ -53,8 +53,8 @@ fn test_admin_gate_rejects_non_admin() {
     // Initialize so admin is stored.
     client.initialize(&admin);
 
-    // Now try add_issuer with no valid auth (mock_all_auths is still active,
-    // but the admin address used for init won't match the non_admin calling add_issuer)
+    // Clear mocks so no valid auth is provided for add_issuer
+    e.mock_auths(&[]);
     let result = client.try_add_issuer(&non_admin, &None, &None, &None);
 
     assert!(result.is_err(), "non-admin call must fail");

--- a/contracts/vc-issuer-registry/src/test.rs
+++ b/contracts/vc-issuer-registry/src/test.rs
@@ -5,7 +5,6 @@ extern crate std;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 use crate::contract::{VcIssuerRegistryContract, VcIssuerRegistryContractClient};
-use crate::error::ContractError;
 
 fn setup() -> (Env, VcIssuerRegistryContractClient<'static>) {
     let e = Env::default();

--- a/contracts/vc-issuer-registry/src/test.rs
+++ b/contracts/vc-issuer-registry/src/test.rs
@@ -1,0 +1,129 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::contract::{VcIssuerRegistryContract, VcIssuerRegistryContractClient};
+use crate::error::ContractError;
+
+fn setup() -> (Env, VcIssuerRegistryContractClient<'static>) {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(VcIssuerRegistryContract, ());
+    let client = VcIssuerRegistryContractClient::new(&e, &contract_id);
+    (e, client)
+}
+
+// ---------------------------------------------------------------------------
+// test_initialize_sets_admin
+// ---------------------------------------------------------------------------
+#[test]
+fn test_initialize_sets_admin() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+
+    client.initialize(&admin);
+
+    assert_eq!(client.admin(), admin);
+}
+
+// ---------------------------------------------------------------------------
+// test_initialize_only_once
+// ---------------------------------------------------------------------------
+#[test]
+#[should_panic(expected = "AlreadyInitialized")]
+fn test_initialize_only_once() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.initialize(&admin); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// test_admin_gate_rejects_non_admin
+// ---------------------------------------------------------------------------
+#[test]
+fn test_admin_gate_rejects_non_admin() {
+    let (e, client) = setup(); // mock_all_auths is active
+    let admin = Address::generate(&e);
+    let non_admin = Address::generate(&e);
+
+    // Initialize so admin is stored.
+    client.initialize(&admin);
+
+    // Temporarily replace mock so only non_admin's signature is presented.
+    // require_admin() will call admin.require_auth() — that auth won't be
+    // satisfied, so Soroban raises a host error (auth failure), not our
+    // ContractError::Unauthorized. We verify the call simply fails.
+    let result = {
+        // Clear all-auth mock and provide only non_admin auth.
+        let e2 = Env::default();
+        e2.mock_auths(&[]);
+        let cid2 = e2.register(VcIssuerRegistryContract, ());
+        let c2 = VcIssuerRegistryContractClient::new(&e2, &cid2);
+        // mock_all_auths for init only
+        e2.mock_all_auths();
+        c2.initialize(&admin);
+        // Now clear mocks and try add_issuer with no valid auth
+        e2.mock_auths(&[]);
+        c2.try_add_issuer(&non_admin, &None, &None, &None)
+    };
+
+    assert!(result.is_err(), "non-admin call must fail");
+}
+
+// ---------------------------------------------------------------------------
+// Additional happy-path smoke tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_add_and_get_issuer() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.add_issuer(&issuer, &None, &None, &None);
+
+    let record = client.get_issuer(&issuer);
+    assert!(record.allowed);
+}
+
+#[test]
+#[should_panic(expected = "IssuerAlreadyExists")]
+fn test_add_issuer_duplicate_panics() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.add_issuer(&issuer, &None, &None, &None);
+    client.add_issuer(&issuer, &None, &None, &None); // must panic
+}
+
+#[test]
+fn test_set_issuer_allowed_false() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.add_issuer(&issuer, &None, &None, &None);
+    assert!(client.is_allowed(&issuer));
+
+    client.set_issuer_allowed(&issuer, &false);
+    assert!(!client.is_allowed(&issuer));
+}
+
+#[test]
+#[should_panic(expected = "IssuerNotFound")]
+fn test_get_issuer_not_found_panics() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.get_issuer(&issuer); // must panic
+}


### PR DESCRIPTION
## Summary

this pr Closes #6 

Adds the `vc-issuer-registry` contract scaffold as a second standalone Soroban contract in this repo. This separates issuer governance ("who is allowed to issue") from VC storage logic in `vc-vault`.

## What's included

- `contracts/vc-issuer-registry/Cargo.toml` — workspace-inheriting crate using the same Soroban version/conventions as `vc-vault`
- `src/error.rs` — typed `ContractError` enum: `Unauthorized`, `AlreadyInitialized`, `IssuerNotFound`, `IssuerAlreadyExists`, `InvalidMetadata`, `NotInitialized`
- `src/storage.rs` — `DataKey` enum, `IssuerRecord` struct, instance/persistent helpers with TTL management
- `src/contract.rs` — `initialize(admin)` (one-time, admin-gated), `require_admin()` helper, full CRUD entry points, read-only queries
- `src/test.rs` — all 3 required tests (`test_initialize_sets_admin`, `test_initialize_only_once`, `test_admin_gate_rejects_non_admin`) plus 3 additional smoke tests
- `README.md` — entry points table, storage layout, error codes, build/test commands
- Root `Cargo.toml` updated to include `contracts/vc-issuer-registry` in workspace members

## Acceptance criteria checklist

- [x] `initialize(admin)` stores admin and cannot be called twice
- [x] `require_admin()` helper gates all admin-only methods
- [x] `DataKey` + `IssuerRecord` storage layout defined
- [x] Error enum with all required variants
- [x] Zero diagnostics — compiles on both native and WASM targets
- [x] All required tests present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a VC issuer registry contract: admin-managed allowlist with per-issuer metadata, lifecycle operations, access checks, and query endpoints.

* **Documentation**
  * Added README describing entry points, events, errors, storage behavior, and build/test instructions.

* **Tests**
  * Added tests covering initialization, authorization, issuer lifecycle, and query behaviors.

* **Chores**
  * Registered the new contract in the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->