### PR TITLE
Feat/issuer registry api

### DIFF
--- a/contracts/vc-issuer-registry/README.md
+++ b/contracts/vc-issuer-registry/README.md
@@ -26,36 +26,60 @@ pub struct IssuerRecord {
 
 ## Entry points
 
-| Function                                | Auth  | Description                             |
-| --------------------------------------- | ----- | --------------------------------------- |
-| `initialize(admin)`                     | admin | One-time init; stores admin             |
-| `add_issuer(issuer, name, did, url)`    | admin | Register a new issuer                   |
-| `update_issuer(issuer, name, did, url)` | admin | Update issuer metadata                  |
-| `set_issuer_allowed(issuer, allowed)`   | admin | Toggle allowlist flag                   |
-| `remove_issuer(issuer)`                 | admin | Remove issuer from registry             |
-| `get_issuer(issuer)`                    | —     | Return full `IssuerRecord`              |
-| `is_allowed(issuer)`                    | —     | Return `true` if registered and allowed |
-| `admin()`                               | —     | Return current admin address            |
-| `version()`                             | —     | Return crate version string             |
+| Function                                        | Auth  | Description                                |
+| ----------------------------------------------- | ----- | ------------------------------------------ |
+| `initialize(admin)`                             | admin | One-time init; stores admin                |
+| `add_issuer(issuer, name, did, url)`            | admin | Register a new issuer (allowed = true)     |
+| `set_issuer_metadata(issuer, name, did, url)`   | admin | Update metadata; preserves `allowed` flag  |
+| `set_issuer_allowed(issuer, allowed)`           | admin | Toggle allowlist flag                      |
+| `remove_issuer(issuer)`                         | admin | **Delete** issuer record from registry     |
+| `get_issuer(issuer)`                            | —     | Return full `IssuerRecord` (panics if missing) |
+| `is_issuer_allowed(issuer)`                     | —     | Return `true` if registered **and** allowed |
+| `admin()`                                       | —     | Return current admin address               |
+| `version()`                                     | —     | Return crate version string                |
+
+### Removal semantics
+
+`remove_issuer` **deletes** the on-chain record entirely (hard delete). After removal:
+
+- `is_issuer_allowed` returns `false`.
+- `get_issuer` panics with `IssuerNotFound`.
+- The same address can be re-added later with `add_issuer`.
+
+This behaviour keeps storage costs predictable and avoids zombie records.
+
+### Metadata validation
+
+`did` and `url` fields are bounded to a maximum of **256 bytes** each.
+`add_issuer` and `set_issuer_metadata` will panic with `InvalidMetadata` if
+either field exceeds this limit. `name` uses the `Symbol` type which is already
+bounded by the Soroban host.
+
+### set_issuer_metadata safety
+
+`set_issuer_metadata` updates **only** the metadata fields (`name`, `did`, `url`).
+It does **not** modify the `allowed` flag. In particular, calling it on a
+disabled issuer will **not** re-enable it.
 
 ## Error codes
 
-| Code | Variant               | Meaning                            |
-| ---- | --------------------- | ---------------------------------- |
-| 1    | `AlreadyInitialized`  | `initialize` called more than once |
-| 2    | `IssuerNotFound`      | Issuer not in registry             |
-| 3    | `IssuerAlreadyExists` | Issuer already registered          |
-| 4    | `NotInitialized`      | Contract not yet initialized       |
+| Code | Variant               | Meaning                                |
+| ---- | --------------------- | -------------------------------------- |
+| 1    | `AlreadyInitialized`  | `initialize` called more than once     |
+| 2    | `IssuerNotFound`      | Issuer not in registry                 |
+| 3    | `IssuerAlreadyExists` | Issuer already registered              |
+| 4    | `NotInitialized`      | Contract not yet initialized           |
+| 5    | `InvalidMetadata`     | Metadata field exceeds max byte length |
 
 ## Events
 
-| Event              | Emitted by           | Fields                           |
-| ------------------ | -------------------- | -------------------------------- |
-| `Initialized`      | `initialize`         | `admin: Address`                 |
-| `IssuerAdded`      | `add_issuer`         | `issuer: Address`                |
-| `IssuerUpdated`    | `update_issuer`      | `issuer: Address`                |
-| `IssuerAllowedSet` | `set_issuer_allowed` | `issuer: Address, allowed: bool` |
-| `IssuerRemoved`    | `remove_issuer`      | `issuer: Address`                |
+| Event              | Emitted by             | Fields                           |
+| ------------------ | ---------------------- | -------------------------------- |
+| `Initialized`      | `initialize`           | `admin: Address`                 |
+| `IssuerAdded`      | `add_issuer`           | `issuer: Address`                |
+| `MetadataUpdated`  | `set_issuer_metadata`  | `issuer: Address`                |
+| `IssuerAllowedSet` | `set_issuer_allowed`   | `issuer: Address, allowed: bool` |
+| `IssuerRemoved`    | `remove_issuer`        | `issuer: Address`                |
 
 ## Build & test
 

--- a/contracts/vc-issuer-registry/src/contract.rs
+++ b/contracts/vc-issuer-registry/src/contract.rs
@@ -7,6 +7,9 @@ use soroban_sdk::{contract, contractimpl, contractmeta, panic_with_error, Addres
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Maximum allowed byte length for `did` and `url` metadata fields.
+const MAX_METADATA_BYTES: u32 = 256;
+
 contractmeta!(
     key = "Description",
     val = "VC Issuer Registry: on-chain allowlist and metadata registry for VC issuers",
@@ -46,6 +49,7 @@ impl VcIssuerRegistryContract {
         url: Option<Bytes>,
     ) {
         require_admin(&e);
+        validate_metadata(&e, &did, &url);
         if storage::has_issuer(&e, &issuer) {
             panic_with_error!(&e, ContractError::IssuerAlreadyExists);
         }
@@ -56,7 +60,8 @@ impl VcIssuerRegistryContract {
     }
 
     /// Update metadata for an existing issuer. Fails if not registered.
-    pub fn update_issuer(
+    /// Does **not** re-add a removed issuer — the `allowed` flag is preserved.
+    pub fn set_issuer_metadata(
         e: Env,
         issuer: Address,
         name: Option<Symbol>,
@@ -64,6 +69,7 @@ impl VcIssuerRegistryContract {
         url: Option<Bytes>,
     ) {
         require_admin(&e);
+        validate_metadata(&e, &did, &url);
         let mut record = storage::read_issuer(&e, &issuer)
             .unwrap_or_else(|| panic_with_error!(&e, ContractError::IssuerNotFound));
         record.name = name;
@@ -71,7 +77,7 @@ impl VcIssuerRegistryContract {
         record.url = url;
         storage::write_issuer(&e, &issuer, &record);
         storage::extend_instance_ttl(&e);
-        events::issuer_updated(&e, &issuer);
+        events::metadata_updated(&e, &issuer);
     }
 
     /// Set the `allowed` flag for an issuer (enable / disable without removing).
@@ -86,6 +92,9 @@ impl VcIssuerRegistryContract {
     }
 
     /// Remove an issuer from the registry entirely.
+    /// **Behavior:** the record is deleted (not soft-disabled). After removal,
+    /// `is_issuer_allowed` returns `false` and `get_issuer` panics with
+    /// `IssuerNotFound`.
     pub fn remove_issuer(e: Env, issuer: Address) {
         require_admin(&e);
         if !storage::has_issuer(&e, &issuer) {
@@ -108,7 +117,7 @@ impl VcIssuerRegistryContract {
     }
 
     /// Returns true if the issuer is registered and currently allowed.
-    pub fn is_allowed(e: Env, issuer: Address) -> bool {
+    pub fn is_issuer_allowed(e: Env, issuer: Address) -> bool {
         storage::extend_instance_ttl(&e);
         storage::read_issuer(&e, &issuer)
             .map(|r| r.allowed)
@@ -142,4 +151,19 @@ fn require_admin(e: &Env) {
     }
     let admin = storage::read_admin(e);
     admin.require_auth();
+}
+
+/// Validates metadata field sizes. Panics with `InvalidMetadata` if `did` or
+/// `url` exceeds [`MAX_METADATA_BYTES`].
+fn validate_metadata(e: &Env, did: &Option<Bytes>, url: &Option<Bytes>) {
+    if let Some(d) = did {
+        if d.len() > MAX_METADATA_BYTES {
+            panic_with_error!(e, ContractError::InvalidMetadata);
+        }
+    }
+    if let Some(u) = url {
+        if u.len() > MAX_METADATA_BYTES {
+            panic_with_error!(e, ContractError::InvalidMetadata);
+        }
+    }
 }

--- a/contracts/vc-issuer-registry/src/error.rs
+++ b/contracts/vc-issuer-registry/src/error.rs
@@ -14,4 +14,6 @@ pub enum ContractError {
     IssuerAlreadyExists = 3,
     /// Contract has not been initialized yet.
     NotInitialized = 4,
+    /// Metadata field exceeds maximum allowed size.
+    InvalidMetadata = 5,
 }

--- a/contracts/vc-issuer-registry/src/events.rs
+++ b/contracts/vc-issuer-registry/src/events.rs
@@ -13,7 +13,7 @@ pub struct IssuerAdded {
 }
 
 #[contractevent]
-pub struct IssuerUpdated {
+pub struct MetadataUpdated {
     pub issuer: Address,
 }
 
@@ -42,8 +42,8 @@ pub fn issuer_added(e: &Env, issuer: &Address) {
     .publish(e);
 }
 
-pub fn issuer_updated(e: &Env, issuer: &Address) {
-    IssuerUpdated {
+pub fn metadata_updated(e: &Env, issuer: &Address) {
+    MetadataUpdated {
         issuer: issuer.clone(),
     }
     .publish(e);

--- a/contracts/vc-issuer-registry/src/test.rs
+++ b/contracts/vc-issuer-registry/src/test.rs
@@ -2,7 +2,7 @@
 
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, Symbol};
 
 use crate::contract::{VcIssuerRegistryContract, VcIssuerRegistryContractClient};
 
@@ -41,44 +41,40 @@ fn test_initialize_only_once() {
 }
 
 // ---------------------------------------------------------------------------
-// test_admin_gate_rejects_non_admin
+// test_add_issuer_happy_path
+//   — Verifies add_issuer stores the record, is_issuer_allowed returns true,
+//     and get_issuer returns the correct metadata.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_admin_gate_rejects_non_admin() {
-    let (e, client) = setup();
-    let admin = Address::generate(&e);
-    let non_admin = Address::generate(&e);
-
-    // Initialize so admin is stored.
-    client.initialize(&admin);
-
-    // Clear mocks so no valid auth is provided for add_issuer
-    e.mock_auths(&[]);
-    let result = client.try_add_issuer(&non_admin, &None, &None, &None);
-
-    assert!(result.is_err(), "non-admin call must fail");
-}
-
-// ---------------------------------------------------------------------------
-// Additional happy-path smoke tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_add_and_get_issuer() {
+fn test_add_issuer_happy_path() {
     let (e, client) = setup();
     let admin = Address::generate(&e);
     let issuer = Address::generate(&e);
 
     client.initialize(&admin);
-    client.add_issuer(&issuer, &None, &None, &None);
+
+    let name = Symbol::new(&e, "TestIssuer");
+    let did = Bytes::from_slice(&e, b"did:example:123");
+    let url = Bytes::from_slice(&e, b"https://example.com");
+
+    client.add_issuer(&issuer, &Some(name.clone()), &Some(did.clone()), &Some(url.clone()));
+
+    assert!(client.is_issuer_allowed(&issuer));
 
     let record = client.get_issuer(&issuer);
     assert!(record.allowed);
+    assert_eq!(record.name, Some(name));
+    assert_eq!(record.did, Some(did));
+    assert_eq!(record.url, Some(url));
 }
 
+// ---------------------------------------------------------------------------
+// test_add_issuer_duplicate_rejected
+//   — Second add_issuer with same address must fail with IssuerAlreadyExists.
+// ---------------------------------------------------------------------------
 #[test]
 #[should_panic]
-fn test_add_issuer_duplicate_panics() {
+fn test_add_issuer_duplicate_rejected() {
     let (e, client) = setup();
     let admin = Address::generate(&e);
     let issuer = Address::generate(&e);
@@ -88,20 +84,161 @@ fn test_add_issuer_duplicate_panics() {
     client.add_issuer(&issuer, &None, &None, &None); // must panic
 }
 
+// ---------------------------------------------------------------------------
+// test_remove_issuer_then_disallowed
+//   — After removal is_issuer_allowed must return false, and get_issuer
+//     must panic with IssuerNotFound.
+// ---------------------------------------------------------------------------
 #[test]
-fn test_set_issuer_allowed_false() {
+fn test_remove_issuer_then_disallowed() {
     let (e, client) = setup();
     let admin = Address::generate(&e);
     let issuer = Address::generate(&e);
 
     client.initialize(&admin);
     client.add_issuer(&issuer, &None, &None, &None);
-    assert!(client.is_allowed(&issuer));
+    assert!(client.is_issuer_allowed(&issuer));
 
-    client.set_issuer_allowed(&issuer, &false);
-    assert!(!client.is_allowed(&issuer));
+    client.remove_issuer(&issuer);
+
+    // is_issuer_allowed returns false for a removed issuer.
+    assert!(!client.is_issuer_allowed(&issuer));
+
+    // get_issuer must fail for a removed issuer.
+    let result = client.try_get_issuer(&issuer);
+    assert!(result.is_err(), "get_issuer after remove must fail");
 }
 
+// ---------------------------------------------------------------------------
+// test_remove_issuer_not_found
+//   — Removing a non-existent issuer must fail.
+// ---------------------------------------------------------------------------
+#[test]
+#[should_panic]
+fn test_remove_issuer_not_found() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.remove_issuer(&issuer); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// test_set_metadata_updates_fields
+//   — set_issuer_metadata replaces name/did/url, and get_issuer reflects
+//     the new values.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_set_metadata_updates_fields() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+
+    let name_v1 = Symbol::new(&e, "V1");
+    let did_v1 = Bytes::from_slice(&e, b"did:v1");
+    let url_v1 = Bytes::from_slice(&e, b"https://v1.example.com");
+    client.add_issuer(&issuer, &Some(name_v1), &Some(did_v1), &Some(url_v1));
+
+    // Update metadata
+    let name_v2 = Symbol::new(&e, "V2");
+    let did_v2 = Bytes::from_slice(&e, b"did:v2");
+    let url_v2 = Bytes::from_slice(&e, b"https://v2.example.com");
+    client.set_issuer_metadata(&issuer, &Some(name_v2.clone()), &Some(did_v2.clone()), &Some(url_v2.clone()));
+
+    let record = client.get_issuer(&issuer);
+    assert_eq!(record.name, Some(name_v2));
+    assert_eq!(record.did, Some(did_v2));
+    assert_eq!(record.url, Some(url_v2));
+    // allowed flag must not change
+    assert!(record.allowed);
+}
+
+// ---------------------------------------------------------------------------
+// test_set_metadata_preserves_allowed_false
+//   — set_issuer_metadata must NOT re-enable a disabled issuer.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_set_metadata_preserves_allowed_false() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.add_issuer(&issuer, &None, &None, &None);
+
+    // Disable
+    client.set_issuer_allowed(&issuer, &false);
+    assert!(!client.is_issuer_allowed(&issuer));
+
+    // Update metadata — must keep allowed == false
+    let name = Symbol::new(&e, "Updated");
+    client.set_issuer_metadata(&issuer, &Some(name), &None, &None);
+
+    let record = client.get_issuer(&issuer);
+    assert!(!record.allowed, "set_issuer_metadata must not re-enable a disabled issuer");
+}
+
+// ---------------------------------------------------------------------------
+// test_set_metadata_on_nonexistent_fails
+// ---------------------------------------------------------------------------
+#[test]
+#[should_panic]
+fn test_set_metadata_on_nonexistent_fails() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.set_issuer_metadata(&issuer, &None, &None, &None); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// test_non_admin_cannot_mutate
+//   — A non-admin caller must be rejected when calling add_issuer.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_non_admin_cannot_mutate() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let _non_admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+
+    // Clear mocks so no valid auth is provided for add_issuer
+    e.mock_auths(&[]);
+    let result = client.try_add_issuer(&issuer, &None, &None, &None);
+
+    assert!(result.is_err(), "non-admin call must fail");
+}
+
+// ---------------------------------------------------------------------------
+// test_set_issuer_allowed_toggle
+//   — Toggle allowed flag and verify is_issuer_allowed tracks correctly.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_set_issuer_allowed_toggle() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+    client.add_issuer(&issuer, &None, &None, &None);
+    assert!(client.is_issuer_allowed(&issuer));
+
+    client.set_issuer_allowed(&issuer, &false);
+    assert!(!client.is_issuer_allowed(&issuer));
+
+    client.set_issuer_allowed(&issuer, &true);
+    assert!(client.is_issuer_allowed(&issuer));
+}
+
+// ---------------------------------------------------------------------------
+// test_get_issuer_not_found_panics
+// ---------------------------------------------------------------------------
 #[test]
 #[should_panic]
 fn test_get_issuer_not_found_panics() {
@@ -111,4 +248,71 @@ fn test_get_issuer_not_found_panics() {
 
     client.initialize(&admin);
     client.get_issuer(&issuer); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// test_is_issuer_allowed_returns_false_for_unknown
+//   — is_issuer_allowed gracefully returns false for an unknown address.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_is_issuer_allowed_returns_false_for_unknown() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let unknown = Address::generate(&e);
+
+    client.initialize(&admin);
+    assert!(!client.is_issuer_allowed(&unknown));
+}
+
+// ---------------------------------------------------------------------------
+// test_metadata_validation_did_too_long
+//   — Adding an issuer with a `did` exceeding 256 bytes must fail.
+// ---------------------------------------------------------------------------
+#[test]
+#[should_panic]
+fn test_metadata_validation_did_too_long() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+
+    let long_did = Bytes::from_slice(&e, &[0u8; 257]);
+    client.add_issuer(&issuer, &None, &Some(long_did), &None); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// test_metadata_validation_url_too_long
+//   — Adding an issuer with a `url` exceeding 256 bytes must fail.
+// ---------------------------------------------------------------------------
+#[test]
+#[should_panic]
+fn test_metadata_validation_url_too_long() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+
+    let long_url = Bytes::from_slice(&e, &[0u8; 257]);
+    client.add_issuer(&issuer, &None, &None, &Some(long_url)); // must panic
+}
+
+// ---------------------------------------------------------------------------
+// test_metadata_validation_boundary_ok
+//   — 256-byte did/url should be accepted (boundary check).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_metadata_validation_boundary_ok() {
+    let (e, client) = setup();
+    let admin = Address::generate(&e);
+    let issuer = Address::generate(&e);
+
+    client.initialize(&admin);
+
+    let max_did = Bytes::from_slice(&e, &[b'x'; 256]);
+    let max_url = Bytes::from_slice(&e, &[b'y'; 256]);
+    client.add_issuer(&issuer, &None, &Some(max_did), &Some(max_url));
+
+    assert!(client.is_issuer_allowed(&issuer));
 }


### PR DESCRIPTION
# feat(registry): implement issuer registry API (allowlist + metadata + queries)

## Description
This PR implements the complete public API for the `vc-issuer-registry` contract as specified in [Issue #7](https://github.com/ACTA-Team/contracts-acta/issues/7). The contract serves as a governance-controlled allowlist for Verifiable Credential issuers with support for optional metadata and explicit validation.

## Implementation Details

### API Refactoring & Renaming
To align with the requirements, the following methods were renamed/implemented:
- `update_issuer` → `set_issuer_metadata`: Dedicated metadata update method that preserves the `allowed` status.
- `is_allowed` → `is_issuer_allowed`: Clearer semantic for external queries.
- `add_issuer`: Registers new issuers with a default `allowed = true` state.
- `remove_issuer`: Implements a **hard delete** (record removal) to keep storage clean and costs predictable.

### Metadata Validation
- Implemented `validate_metadata` helper to enforce a **256-byte limit** on `did` and `url` fields.
- Added a new `InvalidMetadata = 5` error code to handle validation failures gracefully.

### Event & Storage
- Renamed the `IssuerUpdated` event to `MetadataUpdated` for better clarity on what changed.
- Maintained the strict `require_admin` gate on all state-mutating functions.

### Documentation
- Refreshed `contracts/vc-issuer-registry/README.md` to document the final API, removal semantics, and metadata constraints.

## Verification Results

### Unit Tests
A total of **16 tests** were implemented/updated in `src/test.rs`, covering:
- Happy paths for all methods.
- Duplicate registration rejection.
- Boundary checks for metadata length (256 bytes).
- Authorization checks for non-admin callers.
- Graceful handling of missing records in queries.

**Test Summary:**
```bash
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Repo-wide Sanity
Verified that changes do not break existing logic in other contracts (e.g., `vc-vault`).
```bash
test result: ok. 60 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Build
Successfully generated the WASM contract:
- **Wasm File**: `target/wasm32v1-none/release/vc_issuer_registry_contract.wasm`
- **Exported Functions**: `add_issuer`, `admin`, `get_issuer`, `initialize`, `is_issuer_allowed`, `remove_issuer`, `set_issuer_allowed`, `set_issuer_metadata`, `version`.

## Related Issues
Closes #7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata validation: issuer metadata fields (DID, URL) now limited to 256 bytes
  * Introduced `InvalidMetadata` error code for validation failures

* **Updates**
  * Contract API refined: function names updated for clarity (`set_issuer_metadata`, `is_issuer_allowed`)
  * Event renamed from `IssuerUpdated` to `MetadataUpdated`

* **Documentation**
  * Updated API documentation with clarified function behavior and validation constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->