### PR TITLE
chore: decouple per-contract versioning from workspace

### DIFF
--- a/contracts/did-stellar-registry/Cargo.toml
+++ b/contracts/did-stellar-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-stellar-registry"
-version = { workspace = true }
+version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/contracts/vc-issuer-registry/Cargo.toml
+++ b/contracts/vc-issuer-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vc-issuer-registry-contract"
-version = { workspace = true }
+version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/contracts/vc-vault/Cargo.toml
+++ b/contracts/vc-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vc-vault-contract"
-version = { workspace = true }
+version = "0.21.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

Each contract now carries its own explicit version instead of inheriting from the workspace. This lets contracts be released independently on different cadences without bumping unrelated crates.

| Contract | Version | Notes |
|---|---|---|
| `vc-vault-contract` | `0.21.0` | Matches existing audit |
| `vc-issuer-registry-contract` | `0.1.0` | First independent version |
| `did-stellar-registry` | `0.1.0` | First release, implements did:stellar v0.1 |

The workspace `version` field remains as a shared default for any future crate that opts in, but no existing contract uses it.