### PR TITLE
chore: add release infrastructure for testnet deployments

### DIFF
--- a/contracts/did-stellar-registry/Cargo.toml
+++ b/contracts/did-stellar-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-stellar-registry"
-version = { workspace = true }
+version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/contracts/vc-issuer-registry/Cargo.toml
+++ b/contracts/vc-issuer-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vc-issuer-registry-contract"
-version = { workspace = true }
+version = "0.1.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/docs/deployments/mainnet.md
+++ b/docs/deployments/mainnet.md
@@ -1,0 +1,18 @@
+# Mainnet Deployments
+
+Network passphrase: `Public Global Stellar Network ; September 2015`  
+RPC: `https://mainnet.sorobanrpc.com`
+
+---
+
+## did-stellar-registry
+
+| Version | Contract ID | Date | Notes |
+|---|---|---|---|
+| — | — | — | Not yet deployed |
+
+## vc-vault
+
+| Version | Contract ID | Date | Notes |
+|---|---|---|---|
+| — | — | — | Not yet deployed |

--- a/docs/deployments/testnet.md
+++ b/docs/deployments/testnet.md
@@ -1,0 +1,18 @@
+# Testnet Deployments
+
+Network passphrase: `Test SDF Network ; September 2015`  
+RPC: `https://soroban-testnet.stellar.org:443`
+
+---
+
+## did-stellar-registry
+
+| Version | Contract ID | Date | Notes |
+|---|---|---|---|
+| — | — | — | Not yet deployed |
+
+## vc-vault
+
+| Version | Contract ID | Date | Notes |
+|---|---|---|---|
+| — | — | — | Not yet deployed |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,50 @@
 #!/bin/sh
 set -eu
 
-# Build the WASM artifact. We keep crate-type=["rlib"] in Cargo.toml so that
-# native builds (tests, fuzzing) never produce a cdylib, which would fail to
-# link sancov symbols on macOS. The --crate-type cdylib flag here is passed
-# directly to rustc, overriding the manifest for this WASM-only invocation.
-cargo rustc \
-    -p vc-vault-contract \
-    --target wasm32v1-none \
-    --release \
-    -- --crate-type cdylib
+# Build and optimize WASM artifacts for one or all contracts.
+#
+# Usage:
+#   ./scripts/build.sh                      # build all contracts
+#   ./scripts/build.sh vc-vault             # build a specific contract
+#
+# Output: target/wasm32v1-none/release/<name>.optimized.wasm
 
-stellar contract optimize \
-    --wasm target/wasm32v1-none/release/vc_vault_contract.wasm
+PACKAGE=${1:-all}
+
+# vc-vault declares crate-type=["rlib"] to keep native test/fuzz builds clean,
+# so we override crate-type at the rustc level for the WASM target.
+build_vc_vault() {
+    cargo rustc \
+        -p vc-vault-contract \
+        --target wasm32v1-none \
+        --release \
+        -- --crate-type cdylib
+    stellar contract optimize \
+        --wasm target/wasm32v1-none/release/vc_vault_contract.wasm
+    echo "Built: target/wasm32v1-none/release/vc_vault_contract.optimized.wasm"
+}
+
+# did-stellar-registry already declares cdylib so a standard cargo build suffices.
+build_did_registry() {
+    cargo build \
+        -p did-stellar-registry \
+        --target wasm32v1-none \
+        --release
+    stellar contract optimize \
+        --wasm target/wasm32v1-none/release/did_stellar_registry.wasm
+    echo "Built: target/wasm32v1-none/release/did_stellar_registry.optimized.wasm"
+}
+
+case "$PACKAGE" in
+    vc-vault)
+        build_vc_vault ;;
+    did-stellar-registry)
+        build_did_registry ;;
+    all)
+        build_vc_vault
+        build_did_registry ;;
+    *)
+        echo "Unknown package: $PACKAGE" >&2
+        echo "Usage: $0 [vc-vault|did-stellar-registry|all]" >&2
+        exit 1 ;;
+esac

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+# Deploy a contract to a Stellar network.
+#
+# Usage:
+#   ./scripts/deploy.sh <package> <network> <source-account>
+#
+#   package:        vc-vault | did-stellar-registry
+#   network:        testnet | mainnet
+#   source-account: stellar keys alias (e.g. acta_deployer)
+#
+# Examples:
+#   ./scripts/deploy.sh did-stellar-registry testnet acta_deployer
+#   ./scripts/deploy.sh vc-vault testnet acta_deployer
+#
+# Prerequisites:
+#   - stellar-cli installed and configured
+#   - Network already added:
+#       stellar config network add testnet \
+#         --rpc-url https://soroban-testnet.stellar.org:443 \
+#         --network-passphrase "Test SDF Network ; September 2015"
+#   - Source account key generated:
+#       stellar keys generate acta_deployer --network <network>
+#   - WASM built:
+#       ./scripts/build.sh <package>
+
+PACKAGE=${1:-}
+NETWORK=${2:-}
+SOURCE=${3:-}
+
+if [ -z "$PACKAGE" ] || [ -z "$NETWORK" ] || [ -z "$SOURCE" ]; then
+    echo "Usage: $0 <package> <network> <source-account>" >&2
+    echo "  package:  vc-vault | did-stellar-registry" >&2
+    echo "  network:  testnet | mainnet" >&2
+    exit 1
+fi
+
+case "$PACKAGE" in
+    vc-vault)
+        WASM="target/wasm32v1-none/release/vc_vault_contract.optimized.wasm"
+        CONSTRUCTOR_ARGS=""
+        ;;
+    did-stellar-registry)
+        WASM="target/wasm32v1-none/release/did_stellar_registry.optimized.wasm"
+        # Requires an admin address at construction.
+        # Defaults to the deployer address; override by setting DID_ADMIN env var.
+        ADMIN=${DID_ADMIN:-$(stellar keys address "$SOURCE" --network "$NETWORK")}
+        CONSTRUCTOR_ARGS="-- --admin $ADMIN"
+        ;;
+    *)
+        echo "Unknown package: $PACKAGE" >&2
+        echo "  package: vc-vault | did-stellar-registry" >&2
+        exit 1 ;;
+esac
+
+if [ ! -f "$WASM" ]; then
+    echo "WASM not found: $WASM" >&2
+    echo "Run: ./scripts/build.sh $PACKAGE" >&2
+    exit 1
+fi
+
+echo "Deploying $PACKAGE to $NETWORK..."
+echo "  WASM: $WASM"
+echo "  Source: $SOURCE"
+
+CONTRACT_ID=$(stellar contract deploy \
+    --wasm "$WASM" \
+    --source "$SOURCE" \
+    --network "$NETWORK" \
+    $CONSTRUCTOR_ARGS)
+
+echo ""
+echo "Contract ID: $CONTRACT_ID"
+echo ""
+echo "Add this entry to docs/deployments/$NETWORK.md:"
+echo ""
+echo "| $PACKAGE | $(date +%Y-%m-%d) | \`$CONTRACT_ID\` | $NETWORK |"


### PR DESCRIPTION
## Summary

- Decouples per-contract versioning from the workspace so each contract can be versioned independently.
- Adds `scripts/deploy.sh` — unified deploy script for both `vc-vault` and `did-stellar-registry` supporting testnet and mainnet.
- Adds `docs/deployments/testnet.md` and `docs/deployments/mainnet.md` as the canonical record of deployed contract IDs per network.