### PR TITLE
chore: record testnet deployments for Tranche 1

### DIFF
--- a/docs/deployments/testnet.md
+++ b/docs/deployments/testnet.md
@@ -9,10 +9,10 @@ RPC: `https://soroban-testnet.stellar.org:443`
 
 | Version | Contract ID | Date | Notes |
 |---|---|---|---|
-| — | — | — | Not yet deployed |
+| 0.1.0 | `CB7ATU7SF5QUKJMSULJDJVWJZVDXC23HTZX6NFUDTSFPVT6MA575NNZJ` | 2026-05-06 | Tranche 1 initial deploy |
 
 ## vc-vault
 
 | Version | Contract ID | Date | Notes |
 |---|---|---|---|
-| — | — | — | Not yet deployed |
+| 0.1.0 | `CC3SQ7UTAQQDQF6PUQMQIGK3BMPB22OKMHE5Y5XELEX3JFAKC72SQOAM` | 2026-05-06 | Tranche 1 initial deploy |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,7 +45,7 @@ case "$PACKAGE" in
         WASM="target/wasm32v1-none/release/did_stellar_registry.optimized.wasm"
         # Requires an admin address at construction.
         # Defaults to the deployer address; override by setting DID_ADMIN env var.
-        ADMIN=${DID_ADMIN:-$(stellar keys address "$SOURCE" --network "$NETWORK")}
+        ADMIN=${DID_ADMIN:-$(stellar keys address "$SOURCE")}
         CONSTRUCTOR_ARGS="-- --admin $ADMIN"
         ;;
     *)


### PR DESCRIPTION
## Summary

- Records the Tranche 1 testnet contract IDs in `docs/deployments/testnet.md`:
  - `did-stellar-registry`: `CB7ATU7SF5QUKJMSULJDJVWJZVDXC23HTZX6NFUDTSFPVT6MA575NNZJ`
  - `vc-vault`: `CC3SQ7UTAQQDQF6PUQMQIGK3BMPB22OKMHE5Y5XELEX3JFAKC72SQOAM`
- Fixes `scripts/deploy.sh`: removes `--network` flag from `stellar keys address`, which was dropped in stellar-cli v26.

## Verification

- [Stellar Expert — did-stellar-registry](https://stellar.expert/explorer/testnet/contract/CB7ATU7SF5QUKJMSULJDJVWJZVDXC23HTZX6NFUDTSFPVT6MA575NNZJ)
- [Stellar Expert — vc-vault](https://stellar.expert/explorer/testnet/contract/CC3SQ7UTAQQDQF6PUQMQIGK3BMPB22OKMHE5Y5XELEX3JFAKC72SQOAM)