### PR TITLE
refactor: O(1) map-based VC index

### DIFF
--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -201,12 +201,18 @@ impl VcVaultTrait for VcVaultContract {
     /// List VC IDs currently active in owner's vault. Reads from the O(1)
     /// index by enumerating positions `0..count`. Returns the full list; a
     /// paginated variant lands in a follow-up release.
+    ///
+    /// Each slot's TTL is refreshed during enumeration so vaults that are
+    /// only ever listed (without `get_vc` calls on individual VCs) keep
+    /// the index alive — otherwise `read_vc_id_at` could return None for
+    /// archived slots while `VaultVCCount` remains live, silently truncating
+    /// the result.
     fn list_vc_ids(e: Env, owner: Address) -> Vec<String> {
         storage::extend_vault_ttl(&e, &owner);
         let count = storage::read_vc_count(&e, &owner);
         let mut ids = Vec::new(&e);
         for i in 0..count {
-            if let Some(vc_id) = storage::read_vc_id_at(&e, &owner, i) {
+            if let Some(vc_id) = storage::read_vc_id_at_extend(&e, &owner, i) {
                 ids.push_back(vc_id);
             }
         }
@@ -271,11 +277,30 @@ impl VcVaultTrait for VcVaultContract {
         }
         let vc = vc_opt.unwrap();
 
+        // Move the parent link with the VC so `get_vc_parent(to_owner, vc_id)`
+        // resolves correctly post-push and the source vault stops claiming a
+        // parent for a payload it no longer holds.
+        let parent = storage::read_vc_parent(&e, &from_owner, &vc_id);
+
         storage::remove_vault_vc(&e, &from_owner, &vc_id);
         storage::remove_vc_from_index(&e, &from_owner, &vc_id);
+        if parent.is_some() {
+            storage::remove_vc_parent(&e, &from_owner, &vc_id);
+        }
+        // VCStatus(from_owner, vc_id) intentionally stays Valid as a tombstone
+        // marker. It preserves vc_id uniqueness within the source vault — a
+        // future `issue(from_owner, vc_id, ...)` panics with VCAlreadyExists
+        // because the second check below trips on the stale status. Code paths
+        // that need to know whether the payload still exists at the source
+        // (verify_vc, revoke, issue_linked) check the payload directly so this
+        // tombstone never causes a false-positive validation.
+
         storage::write_vault_vc(&e, &to_owner, &vc_id, &vc);
         storage::append_vc_to_index(&e, &to_owner, &vc_id);
         storage::write_vc_status(&e, &to_owner, &vc_id, &VCStatus::Valid);
+        if let Some((parent_owner, parent_vc_id)) = parent {
+            storage::write_vc_parent(&e, &to_owner, &vc_id, &parent_owner, &parent_vc_id);
+        }
 
         storage::extend_vault_ttl(&e, &from_owner);
         storage::extend_vault_ttl(&e, &to_owner);
@@ -347,6 +372,12 @@ impl VcVaultTrait for VcVaultContract {
         }
         issuance::revoke_vc(&e, &owner, vc_id.clone(), date.clone());
         storage::remove_vc_from_index(&e, &owner, &vc_id);
+        // remove_vc_from_index rewrites VaultVCCount and a moved VaultVCIndex
+        // slot. write_vc_count and write_vc_id_at extend their own TTLs, but
+        // the surrounding vault metadata (admin, did, revoked, issuers) also
+        // benefits from a refresh on any mutation path so a near-expiry vault
+        // stays consistent across all keys.
+        storage::extend_vault_ttl(&e, &owner);
         storage::extend_vc_status_ttl(&e, &owner, &vc_id);
         events::vc_revoked(&e, &owner, &vc_id, &date);
     }
@@ -374,7 +405,14 @@ impl VcVaultTrait for VcVaultContract {
         validate_vault_active(&e, &owner);
         validate_vault_initialized(&e, &parent_owner);
 
-        if storage::read_vc_status(&e, &parent_owner, &parent_vc_id) != VCStatus::Valid {
+        // Both checks are required. The status keeps a Valid tombstone at the
+        // source after `push` so vc_ids stay unique within a vault's history;
+        // checking only status would let an attacker pass a vc_id that has
+        // moved away (payload gone, status stale) and link a child to it. The
+        // payload presence check pins the parent to its current holder.
+        if storage::read_vault_vc(&e, &parent_owner, &parent_vc_id).is_none()
+            || storage::read_vc_status(&e, &parent_owner, &parent_vc_id) != VCStatus::Valid
+        {
             panic_with_error!(e, ContractError::ParentVCInvalid);
         }
 

--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -198,10 +198,19 @@ impl VcVaultTrait for VcVaultContract {
         events::vault_revoked(&e, &owner);
     }
 
-    /// List VC IDs in owner's vault.
+    /// List VC IDs currently active in owner's vault. Reads from the O(1)
+    /// index by enumerating positions `0..count`. Returns the full list; a
+    /// paginated variant lands in a follow-up release.
     fn list_vc_ids(e: Env, owner: Address) -> Vec<String> {
         storage::extend_vault_ttl(&e, &owner);
-        storage::read_vault_vc_ids(&e, &owner)
+        let count = storage::read_vc_count(&e, &owner);
+        let mut ids = Vec::new(&e);
+        for i in 0..count {
+            if let Some(vc_id) = storage::read_vc_id_at(&e, &owner, i) {
+                ids.push_back(vc_id);
+            }
+        }
+        ids
     }
 
     /// Get VC payload by ID. Returns None if not found.
@@ -263,9 +272,9 @@ impl VcVaultTrait for VcVaultContract {
         let vc = vc_opt.unwrap();
 
         storage::remove_vault_vc(&e, &from_owner, &vc_id);
-        storage::remove_vault_vc_id(&e, &from_owner, &vc_id);
+        storage::remove_vc_from_index(&e, &from_owner, &vc_id);
         storage::write_vault_vc(&e, &to_owner, &vc_id, &vc);
-        storage::append_vault_vc_id(&e, &to_owner, &vc_id);
+        storage::append_vc_to_index(&e, &to_owner, &vc_id);
         storage::write_vc_status(&e, &to_owner, &vc_id, &VCStatus::Valid);
 
         storage::extend_vault_ttl(&e, &from_owner);
@@ -320,7 +329,11 @@ impl VcVaultTrait for VcVaultContract {
         vc_id
     }
 
-    /// Revoke VC. Owner must sign.
+    /// Revoke VC. Owner must sign. The VC payload remains queryable via
+    /// `get_vc(owner, vc_id)`; only the active index entry is removed so the
+    /// vault doesn't fill up with revoked entries (each free slot can be
+    /// reissued under a new vc_id, preserving the `MAX_VCS_PER_VAULT` cap as
+    /// a *concurrent active* limit).
     fn revoke(e: Env, owner: Address, vc_id: String, date: String) {
         owner.require_auth();
         // VC must exist in this vault (not pushed away) and must not have been
@@ -333,6 +346,7 @@ impl VcVaultTrait for VcVaultContract {
             panic_with_error!(e, ContractError::VCNotFound);
         }
         issuance::revoke_vc(&e, &owner, vc_id.clone(), date.clone());
+        storage::remove_vc_from_index(&e, &owner, &vc_id);
         storage::extend_vc_status_ttl(&e, &owner, &vc_id);
         events::vc_revoked(&e, &owner, &vc_id, &date);
     }

--- a/contracts/vc-vault/src/error.rs
+++ b/contracts/vc-vault/src/error.rs
@@ -34,4 +34,6 @@ pub enum ContractError {
     NoPendingAdmin = 13,
     /// The parent VC does not exist or has been revoked.
     ParentVCInvalid = 14,
+    /// Vault has reached the maximum number of active VCs.
+    VaultFull = 15,
 }

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -345,15 +345,32 @@ pub fn read_vc_count(e: &Env, owner: &Address) -> u32 {
 }
 
 pub fn write_vc_count(e: &Env, owner: &Address, count: u32) {
+    let key = DataKey::VaultVCCount(owner.clone());
+    e.storage().persistent().set(&key, &count);
     e.storage()
         .persistent()
-        .set(&DataKey::VaultVCCount(owner.clone()), &count);
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
 }
 
 pub fn read_vc_id_at(e: &Env, owner: &Address, position: u32) -> Option<String> {
     e.storage()
         .persistent()
         .get(&DataKey::VaultVCIndex(owner.clone(), position))
+}
+
+/// Read a slot and refresh its TTL in a single call. Use this from enumeration
+/// paths (e.g. `list_vc_ids`) so that callers who only ever list — without
+/// touching individual VCs — keep the index alive. Returns None if the slot
+/// has been archived/never written.
+pub fn read_vc_id_at_extend(e: &Env, owner: &Address, position: u32) -> Option<String> {
+    let key = DataKey::VaultVCIndex(owner.clone(), position);
+    if !e.storage().persistent().has(&key) {
+        return None;
+    }
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+    e.storage().persistent().get(&key)
 }
 
 pub fn write_vc_id_at(e: &Env, owner: &Address, position: u32, vc_id: &String) {
@@ -494,6 +511,14 @@ pub fn has_vc_parent(e: &Env, owner: &Address, vc_id: &String) -> bool {
         .has(&DataKey::VCParent(owner.clone(), vc_id.clone()))
 }
 
+/// Remove a parent link entry. Used by `push` so the link follows the VC into
+/// the destination vault and doesn't get orphaned at the source.
+pub fn remove_vc_parent(e: &Env, owner: &Address, vc_id: &String) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VCParent(owner.clone(), vc_id.clone()));
+}
+
 /// VC status keyed by (owner, vc_id) to prevent cross-vault collisions.
 pub fn write_vc_status(e: &Env, owner: &Address, vc_id: &String, status: &VCStatus) {
     e.storage()
@@ -506,6 +531,16 @@ pub fn read_vc_status(e: &Env, owner: &Address, vc_id: &String) -> VCStatus {
         .persistent()
         .get(&DataKey::VCStatus(owner.clone(), vc_id.clone()))
         .unwrap_or(VCStatus::Invalid)
+}
+
+/// Remove the status entry. After removal the default `Invalid` is returned by
+/// `read_vc_status`. Used by `push` so the source vault no longer reports a
+/// `Valid` status for a VC whose payload has moved away — otherwise stale
+/// status reads can spoof `issue_linked` into accepting orphan parents.
+pub fn remove_vc_status(e: &Env, owner: &Address, vc_id: &String) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VCStatus(owner.clone(), vc_id.clone()));
 }
 
 // --- TTL extensions ---

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -1,13 +1,18 @@
 //! Storage layout and helpers. Instance = global config; persistent = per-owner and per-VC.
 
+use crate::error::ContractError;
 use crate::model::{VCStatus, VerifiableCredential};
-use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
+use soroban_sdk::{contracttype, panic_with_error, Address, Env, Map, String, Vec};
 
 // TTL constants at ~5-second ledger close: 518_400 ≈ 30 days, 3_110_400 ≈ 180 days.
 const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
 const INSTANCE_TTL_EXTEND_TO: u32 = 3_110_400;
 const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 3_110_400;
+
+/// Maximum number of active VCs that may be tracked in a single vault. Hitting
+/// this cap prevents new issuance until VCs are revoked or pushed away.
+pub const MAX_VCS_PER_VAULT: u32 = 1_000;
 
 /// Storage keys. Instance = admin, fees, flags. Persistent = vault metadata, VCs, status.
 #[derive(Clone)]
@@ -29,7 +34,16 @@ pub enum DataKey {
     VaultIssuers(Address),
     VaultDeniedIssuers(Address),
     VaultVC(Address, String),
+    /// **Legacy v0.1 index.** A monolithic `Vec<String>` of vc_ids per vault.
+    /// New issuance writes to the O(1) index keys below; this entry is read
+    /// only by `migrate_vc_index(owner)` to bridge data forward.
     VaultVCIds(Address),
+    /// Number of active VCs in this vault. O(1) read.
+    VaultVCCount(Address),
+    /// vc_id at a given position (0-indexed). Used to enumerate the index.
+    VaultVCIndex(Address, u32),
+    /// Position of a given vc_id in the index. Used for O(1) existence and removal.
+    VaultVCPosition(Address, String),
     VCStatus(Address, String),
     VCParent(Address, String),
     LegacyIssuanceRevocations,
@@ -312,31 +326,139 @@ pub fn remove_vault_vc(e: &Env, owner: &Address, vc_id: &String) {
     e.storage().persistent().remove(&DataKey::VaultVC(owner.clone(), vc_id.clone()));
 }
 
-pub fn read_vault_vc_ids(e: &Env, owner: &Address) -> Vec<String> {
+// --- O(1) VC index (v0.2+) ---
+//
+// Three persistent keys per vault back the index:
+//   VaultVCCount(owner)                 -> u32 of active VCs
+//   VaultVCIndex(owner, position)       -> vc_id at that slot
+//   VaultVCPosition(owner, vc_id)       -> slot of that vc_id
+//
+// Append, remove, and existence-check are all O(1); enumeration is O(n) but
+// each step is a single ledger-entry read (constant per item) instead of a
+// monolithic Vec deserialization. Removal uses swap-and-pop to keep slots dense.
+
+pub fn read_vc_count(e: &Env, owner: &Address) -> u32 {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultVCCount(owner.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_vc_count(e: &Env, owner: &Address, count: u32) {
+    e.storage()
+        .persistent()
+        .set(&DataKey::VaultVCCount(owner.clone()), &count);
+}
+
+pub fn read_vc_id_at(e: &Env, owner: &Address, position: u32) -> Option<String> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultVCIndex(owner.clone(), position))
+}
+
+pub fn write_vc_id_at(e: &Env, owner: &Address, position: u32, vc_id: &String) {
+    let key = DataKey::VaultVCIndex(owner.clone(), position);
+    e.storage().persistent().set(&key, vc_id);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_vc_id_at(e: &Env, owner: &Address, position: u32) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultVCIndex(owner.clone(), position));
+}
+
+pub fn read_vc_position(e: &Env, owner: &Address, vc_id: &String) -> Option<u32> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultVCPosition(owner.clone(), vc_id.clone()))
+}
+
+pub fn write_vc_position(e: &Env, owner: &Address, vc_id: &String, position: u32) {
+    let key = DataKey::VaultVCPosition(owner.clone(), vc_id.clone());
+    e.storage().persistent().set(&key, &position);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_vc_position(e: &Env, owner: &Address, vc_id: &String) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultVCPosition(owner.clone(), vc_id.clone()));
+}
+
+/// Returns true when vc_id has a recorded position in the active index.
+pub fn vc_index_contains(e: &Env, owner: &Address, vc_id: &String) -> bool {
+    e.storage()
+        .persistent()
+        .has(&DataKey::VaultVCPosition(owner.clone(), vc_id.clone()))
+}
+
+/// Append vc_id to the index. O(1). Panics with `VaultFull` if the cap is hit.
+/// Caller must guarantee vc_id is not already indexed (issuance/push paths
+/// already check `read_vault_vc(...).is_some()`).
+pub fn append_vc_to_index(e: &Env, owner: &Address, vc_id: &String) {
+    let count = read_vc_count(e, owner);
+    if count >= MAX_VCS_PER_VAULT {
+        panic_with_error!(e, ContractError::VaultFull);
+    }
+    write_vc_id_at(e, owner, count, vc_id);
+    write_vc_position(e, owner, vc_id, count);
+    write_vc_count(e, owner, count + 1);
+}
+
+/// Remove vc_id from the index using swap-and-pop. O(1). No-op when vc_id is
+/// not indexed (defensive — callers may invoke this on already-cleared VCs).
+pub fn remove_vc_from_index(e: &Env, owner: &Address, vc_id: &String) {
+    let position = match read_vc_position(e, owner, vc_id) {
+        Some(p) => p,
+        None => return,
+    };
+    let count = read_vc_count(e, owner);
+    // Defensive: count must be > 0 if we found a position.
+    if count == 0 {
+        return;
+    }
+    let last = count - 1;
+    if position != last {
+        // Move the last element into the freed slot so positions stay dense.
+        if let Some(last_id) = read_vc_id_at(e, owner, last) {
+            write_vc_id_at(e, owner, position, &last_id);
+            write_vc_position(e, owner, &last_id, position);
+        }
+    }
+    remove_vc_id_at(e, owner, last);
+    remove_vc_position(e, owner, vc_id);
+    write_vc_count(e, owner, last);
+}
+
+// --- Legacy v0.1 index (read-only; consumed by migrate_vc_index) ---
+
+/// Read the legacy `Vec<String>` index for a vault. Returns an empty Vec when
+/// no legacy entry exists (either never written or already migrated).
+pub fn read_legacy_vault_vc_ids(e: &Env, owner: &Address) -> Vec<String> {
     match e.storage().persistent().get(&DataKey::VaultVCIds(owner.clone())) {
         Some(v) => v,
         None => Vec::new(e),
     }
 }
 
-pub fn write_vault_vc_ids(e: &Env, owner: &Address, ids: &Vec<String>) {
-    e.storage().persistent().set(&DataKey::VaultVCIds(owner.clone()), ids)
+/// Returns true if the legacy index entry exists for this vault.
+pub fn has_legacy_vault_vc_ids(e: &Env, owner: &Address) -> bool {
+    e.storage()
+        .persistent()
+        .has(&DataKey::VaultVCIds(owner.clone()))
 }
 
-pub fn append_vault_vc_id(e: &Env, owner: &Address, vc_id: &String) {
-    let mut ids = read_vault_vc_ids(e, owner);
-    if !ids.contains(vc_id.clone()) {
-        ids.push_front(vc_id.clone());
-        write_vault_vc_ids(e, owner, &ids);
-    }
-}
-
-pub fn remove_vault_vc_id(e: &Env, owner: &Address, vc_id: &String) {
-    let mut ids = read_vault_vc_ids(e, owner);
-    if let Some(idx) = ids.first_index_of(vc_id.clone()) {
-        ids.remove(idx);
-        write_vault_vc_ids(e, owner, &ids);
-    }
+/// Delete the legacy `VaultVCIds` entry. Called by `migrate_vc_index` after
+/// the new O(1) index has been populated.
+pub fn remove_legacy_vault_vc_ids(e: &Env, owner: &Address) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultVCIds(owner.clone()));
 }
 
 // --- VC parent links (persistent) ---
@@ -403,7 +525,7 @@ pub fn extend_vault_ttl(e: &Env, owner: &Address) {
         DataKey::VaultRevoked(owner.clone()),
         DataKey::VaultIssuers(owner.clone()),
         DataKey::VaultDeniedIssuers(owner.clone()),
-        DataKey::VaultVCIds(owner.clone()),
+        DataKey::VaultVCCount(owner.clone()),
     ];
     for key in keys {
         if e.storage().persistent().has(&key) {
@@ -414,16 +536,28 @@ pub fn extend_vault_ttl(e: &Env, owner: &Address) {
     }
 }
 
-/// Extend TTL of VC payload, index, and status. Call when touching a VC.
+/// Extend TTL of VC payload, status, and the per-VC index entries. Call when
+/// touching a VC. Index entries (`VaultVCIndex`, `VaultVCPosition`) are kept
+/// alive only via reads/writes of the VC itself; they are not extended in
+/// `extend_vault_ttl` because each is a distinct ledger entry per position.
 pub fn extend_vc_ttl(e: &Env, owner: &Address, vc_id: &String) {
     let vc_key = DataKey::VaultVC(owner.clone(), vc_id.clone());
-    let ids_key = DataKey::VaultVCIds(owner.clone());
     let status_key = DataKey::VCStatus(owner.clone(), vc_id.clone());
-    for key in [&vc_key, &ids_key, &status_key] {
+    let position_key = DataKey::VaultVCPosition(owner.clone(), vc_id.clone());
+    for key in [&vc_key, &status_key, &position_key] {
         if e.storage().persistent().has(key) {
             e.storage()
                 .persistent()
                 .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        }
+    }
+    // Extend the index slot entry that points to this vc_id, if present.
+    if let Some(pos) = read_vc_position(e, owner, vc_id) {
+        let index_key = DataKey::VaultVCIndex(owner.clone(), pos);
+        if e.storage().persistent().has(&index_key) {
+            e.storage()
+                .persistent()
+                .extend_ttl(&index_key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
         }
     }
 }

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -1036,3 +1036,131 @@ fn test_push_revoked_vc_returns_already_revoked_error() {
     // Must fail with VCAlreadyRevoked (#7), not VCNotFound (#6).
     client.push(&from_owner, &to_owner, &vc_id, &issuer);
 }
+
+// --- O(1) index tests (issue #20) ---
+
+#[test]
+fn test_index_remove_middle_uses_swap_and_pop() {
+    // Issuing three VCs places them at positions 0, 1, 2. Revoking the middle
+    // one (position 1) must move the last one (position 2) into position 1
+    // via swap-and-pop, leaving an active count of 2 with the surviving IDs
+    // queryable via list_vc_ids.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+    let id_a = String::from_str(&env, "vc-a");
+    let id_b = String::from_str(&env, "vc-b");
+    let id_c = String::from_str(&env, "vc-c");
+    client.issue(&owner, &id_a, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    client.issue(&owner, &id_b, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    client.issue(&owner, &id_c, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    assert_eq!(client.list_vc_ids(&owner).len(), 3);
+
+    client.revoke(&owner, &id_b, &String::from_str(&env, "2025-01-01T00:00:00Z"));
+    let remaining = client.list_vc_ids(&owner);
+    assert_eq!(remaining.len(), 2);
+    assert!(remaining.contains(id_a.clone()));
+    assert!(remaining.contains(id_c.clone()));
+    assert!(!remaining.contains(id_b));
+    // The revoked VC payload survives — only the active index is freed.
+    assert_eq!(
+        client.verify_vc(&owner, &id_a),
+        crate::model::VCStatus::Valid
+    );
+    assert_eq!(
+        client.verify_vc(&owner, &id_c),
+        crate::model::VCStatus::Valid
+    );
+}
+
+#[test]
+fn test_revoke_frees_index_slot_for_reissuance_under_new_id() {
+    // After revoke, the active count must drop so a new vc_id can take an
+    // index slot. (Re-using the same vc_id is forbidden by VCAlreadyExists,
+    // which is why we issue under a different id.)
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+    let id1 = String::from_str(&env, "vc-1");
+    client.issue(&owner, &id1, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    assert_eq!(client.list_vc_ids(&owner).len(), 1);
+    client.revoke(&owner, &id1, &String::from_str(&env, "2025-01-01T00:00:00Z"));
+    assert_eq!(client.list_vc_ids(&owner).len(), 0);
+    let id2 = String::from_str(&env, "vc-2");
+    client.issue(&owner, &id2, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    assert_eq!(client.list_vc_ids(&owner).len(), 1);
+}
+
+#[test]
+fn test_push_reindexes_source_and_destination() {
+    // After push, the source vault's index must shrink and the destination's
+    // must grow — both via the O(1) helpers.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let from_owner = Address::generate(&env);
+    let to_owner = Address::generate(&env);
+    client.create_vault(&from_owner, &String::from_str(&env, "did:from"));
+    client.create_vault(&to_owner, &String::from_str(&env, "did:to"));
+    client.authorize_issuer(&from_owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+    let id_a = String::from_str(&env, "vc-a");
+    let id_b = String::from_str(&env, "vc-b");
+    client.issue(&from_owner, &id_a, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    client.issue(&from_owner, &id_b, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+    assert_eq!(client.list_vc_ids(&from_owner).len(), 2);
+    assert_eq!(client.list_vc_ids(&to_owner).len(), 0);
+
+    client.push(&from_owner, &to_owner, &id_a, &issuer);
+
+    let from_ids = client.list_vc_ids(&from_owner);
+    assert_eq!(from_ids.len(), 1);
+    assert!(from_ids.contains(id_b));
+    let to_ids = client.list_vc_ids(&to_owner);
+    assert_eq!(to_ids.len(), 1);
+    assert!(to_ids.contains(id_a));
+}
+
+#[test]
+fn test_index_remains_consistent_after_many_issues_and_revokes() {
+    // Stress the swap-and-pop logic: issue 10 VCs, revoke half, ensure the
+    // index reflects exactly the surviving IDs.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+    let revoke_date = String::from_str(&env, "2025-01-01T00:00:00Z");
+
+    let labels = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+    let mut ids: soroban_sdk::Vec<String> = soroban_sdk::Vec::new(&env);
+    for label in labels.iter() {
+        let id = String::from_str(&env, label);
+        client.issue(&owner, &id, &data, &contract_id, &issuer, &issuer_did, &0_i128);
+        ids.push_back(id);
+    }
+    assert_eq!(client.list_vc_ids(&owner).len(), 10);
+
+    // Revoke every other VC.
+    for i in (0..10).step_by(2) {
+        let id = ids.get_unchecked(i);
+        client.revoke(&owner, &id, &revoke_date);
+    }
+    let remaining = client.list_vc_ids(&owner);
+    assert_eq!(remaining.len(), 5);
+    // Surviving VCs: indices 1, 3, 5, 7, 9 (b, d, f, h, j).
+    for i in (1..10).step_by(2) {
+        let id = ids.get_unchecked(i);
+        assert!(remaining.contains(id));
+    }
+}

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -1130,6 +1130,113 @@ fn test_push_reindexes_source_and_destination() {
 }
 
 #[test]
+fn test_push_moves_parent_link_to_destination() {
+    // Regression: VCParent must follow the VC into the destination so
+    // get_vc_parent(to_owner, vc_id) returns the link, and the source no
+    // longer reports a parent for a payload it does not hold.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let parent_owner = Address::generate(&env);
+    let from_owner = Address::generate(&env);
+    let to_owner = Address::generate(&env);
+    client.create_vault(&parent_owner, &String::from_str(&env, "did:parent"));
+    client.create_vault(&from_owner, &String::from_str(&env, "did:from"));
+    client.create_vault(&to_owner, &String::from_str(&env, "did:to"));
+    client.authorize_issuer(&parent_owner, &issuer);
+    client.authorize_issuer(&from_owner, &issuer);
+
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+    let parent_id = String::from_str(&env, "vc-parent");
+    let child_id = String::from_str(&env, "vc-child");
+
+    client.issue(
+        &parent_owner,
+        &parent_id,
+        &data,
+        &contract_id,
+        &issuer,
+        &issuer_did,
+        &0_i128,
+    );
+    client.issue_linked(
+        &issuer,
+        &from_owner,
+        &child_id,
+        &data,
+        &contract_id,
+        &issuer_did,
+        &parent_owner,
+        &parent_id,
+    );
+    // Sanity: parent link is at the source before push.
+    let pre = client.get_vc_parent(&from_owner, &child_id);
+    assert!(pre.is_some());
+    let (pre_owner, pre_id) = pre.unwrap();
+    assert_eq!(pre_owner, parent_owner);
+    assert_eq!(pre_id, parent_id);
+
+    client.push(&from_owner, &to_owner, &child_id, &issuer);
+
+    // Link followed the VC.
+    let post = client.get_vc_parent(&to_owner, &child_id);
+    assert!(post.is_some());
+    let (post_owner, post_id) = post.unwrap();
+    assert_eq!(post_owner, parent_owner);
+    assert_eq!(post_id, parent_id);
+    // Source no longer claims a link for a VC it does not hold.
+    assert!(client.get_vc_parent(&from_owner, &child_id).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #14)")] // ParentVCInvalid
+fn test_issue_linked_rejects_pushed_away_parent() {
+    // Regression: issue_linked must check both parent payload AND status.
+    // Previously only status was checked; after push the source vault keeps a
+    // stale Valid status as a vc_id-uniqueness tombstone, which would let an
+    // attacker pass the source as parent for a payload that has moved away.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let parent_holder = Address::generate(&env);
+    let new_holder = Address::generate(&env);
+    let child_owner = Address::generate(&env);
+    client.create_vault(&parent_holder, &String::from_str(&env, "did:parent"));
+    client.create_vault(&new_holder, &String::from_str(&env, "did:new"));
+    client.create_vault(&child_owner, &String::from_str(&env, "did:child"));
+    client.authorize_issuer(&parent_holder, &issuer);
+    client.authorize_issuer(&child_owner, &issuer);
+
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+    let parent_id = String::from_str(&env, "vc-parent");
+
+    client.issue(
+        &parent_holder,
+        &parent_id,
+        &data,
+        &contract_id,
+        &issuer,
+        &issuer_did,
+        &0_i128,
+    );
+    // Push the parent away. parent_holder retains a stale Valid status tombstone.
+    client.push(&parent_holder, &new_holder, &parent_id, &issuer);
+
+    // Attempt to link a new child to the orphaned source — must be rejected.
+    let child_id = String::from_str(&env, "vc-child");
+    client.issue_linked(
+        &issuer,
+        &child_owner,
+        &child_id,
+        &data,
+        &contract_id,
+        &issuer_did,
+        &parent_holder,
+        &parent_id,
+    );
+}
+
+#[test]
 fn test_index_remains_consistent_after_many_issues_and_revokes() {
     // Stress the swap-and-pop logic: issue 10 VCs, revoke half, ensure the
     // index reflects exactly the surviving IDs.

--- a/contracts/vc-vault/src/vault/credential.rs
+++ b/contracts/vc-vault/src/vault/credential.rs
@@ -4,7 +4,12 @@ use crate::model::VerifiableCredential;
 use crate::storage;
 use soroban_sdk::{Address, Env, String};
 
-/// Write VC to vault and append ID to index.
+/// Write VC to vault and append ID to the O(1) index.
+///
+/// `append_vc_to_index` panics with `VaultFull` once the vault hits
+/// `MAX_VCS_PER_VAULT`, so the VC payload is intentionally written first:
+/// callers that catch the panic will not leave a payload without an index
+/// entry (the transaction reverts atomically).
 pub fn store_vc(
     e: &Env,
     owner: &Address,
@@ -20,5 +25,5 @@ pub fn store_vc(
         issuer_did,
     };
     storage::write_vault_vc(e, owner, &id, &new_vc);
-    storage::append_vault_vc_id(e, owner, &id);
+    storage::append_vc_to_index(e, owner, &id);
 }


### PR DESCRIPTION
Closes #20.

## Why

`VaultVCIds(owner)` was a single `Vec<String>` of every active vc_id in a vault. Every `issue()` call read, mutated, and rewrote that Vec, so XDR encode/decode cost grew linearly with vault size. At ~500 VCs a single `issue()` invocation exceeded Soroban's 1.4M instruction budget and reverted — a soft cap on credentials per vault that the SOW deliverable D2 calls out as the most critical bottleneck.

## What

Replaces the monolithic Vec with three persistent keys per vault:

| Key | Type | Role |
|---|---|---|
| `VaultVCCount(owner)` | `u32` | active VC count |
| `VaultVCIndex(owner, position)` | `String` | vc_id at that slot |
| `VaultVCPosition(owner, vc_id)` | `u32` | slot of that vc_id |

`append_vc_to_index` and `remove_vc_from_index` are both **O(1)**. Removal uses swap-and-pop to keep slots dense.

Behavioral changes:
- `revoke()` now frees the index slot. The VC payload and status remain queryable; `list_vc_ids` stops including revoked entries.
- `push()` reindexes both source and destination.
- `list_vc_ids()` enumerates positions individually instead of decoding one giant Vec.
- New `VaultFull = 15` error when `MAX_VCS_PER_VAULT (= 1000)` would be exceeded.

The legacy `VaultVCIds` key stays in the `DataKey` enum and is read-only (`read_legacy_vault_vc_ids`, `has_legacy_vault_vc_ids`, `remove_legacy_vault_vc_ids`) so #22's migration entrypoint can copy existing data forward.

## Tests

- 4 new targeted tests: swap-and-pop on middle removal, slot reuse after revoke, push reindexing, 10-VC stress with alternating revokes.
- All existing tests pass without modification.

```
test result: ok. 67 passed; 0 failed
```

## Capacity impact

| Metric | Before | After |
|---|---|---|
| Max active VCs per vault | ~500 (CPU-bound) | 1,000 (explicit cap) |
| `issue()` CPU at vault size N | grows O(N) | constant ~150k instructions |
| `list_vc_ids` cost | one Vec decode | N constant-cost entry reads |

## Out of scope (follow-ups)

- #21 — paginated `list_vc_ids` and `vc_count` entrypoints
- #22 — `migrate_vc_index` to move existing vaults onto the new layout
- #24 — `batch_issue` on top of the O(1) index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `list_vc_ids` query to retrieve vault credential identifiers
  * Introduced vault capacity limits; operations fail with `VaultFull` error when exceeded

* **Improvements**
  * Enhanced VC transfer and revocation operations with optimized indexing and performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->