### PR TITLE
feat: add migrate_vc_index for v0.1 → v0.2 vault migration

### DIFF
--- a/contracts/vc-vault/src/api/mod.rs
+++ b/contracts/vc-vault/src/api/mod.rs
@@ -59,6 +59,7 @@ pub trait VcVaultTrait {
     );
     fn get_vc_parent(e: Env, owner: Address, vc_id: String) -> Option<(Address, String)>;
     fn migrate(e: Env, owner: Address);
+    fn migrate_vc_index(e: Env, owner: Address);
     fn create_sponsored_vault(e: Env, sponsor: Address, owner: Address, did_uri: String);
     fn set_sponsored_vault_open_to_all(e: Env, open: bool);
     fn get_sponsored_vault_open_to_all(e: Env) -> bool;

--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -538,6 +538,39 @@ impl VcVaultTrait for VcVaultContract {
         storage::remove_legacy_vault_vcs(&e, &owner);
         storage::extend_vault_ttl(&e, &owner);
     }
+
+    /// Migrate the v0.1 `Vec<String>` index at `VaultVCIds(owner)` into the
+    /// O(1) index introduced in v0.2 (`VaultVCCount`, `VaultVCIndex`,
+    /// `VaultVCPosition`).
+    ///
+    /// **No auth.** The migration is deterministic from on-chain state: it
+    /// only relocates the same vc_ids to the new key layout, so any caller
+    /// (the owner, an SDK background worker, an indexer) can drive it.
+    /// Letting backend services migrate proactively avoids a "first write
+    /// after upgrade is expensive" cliff for end users.
+    ///
+    /// Semantics:
+    /// - Panics with `VCSAlreadyMigrated` when the new index already has
+    ///   entries (`vc_count > 0`). Catches both double-calls and post-v0.2
+    ///   vaults that never had legacy data.
+    /// - When the legacy entry is absent and the new index is empty (vault
+    ///   created fresh post-upgrade with no VCs yet) the call is a no-op.
+    /// - Iterates the legacy Vec in stored order and `append_vc_to_index`
+    ///   each id, preserving relative ordering.
+    /// - Removes `VaultVCIds(owner)` afterward so a future call panics.
+    fn migrate_vc_index(e: Env, owner: Address) {
+        if storage::read_vc_count(&e, &owner) > 0 {
+            panic_with_error!(e, ContractError::VCSAlreadyMigrated);
+        }
+        let legacy_ids = storage::read_legacy_vault_vc_ids(&e, &owner);
+        for vc_id in legacy_ids.iter() {
+            storage::append_vc_to_index(&e, &owner, &vc_id);
+        }
+        if storage::has_legacy_vault_vc_ids(&e, &owner) {
+            storage::remove_legacy_vault_vc_ids(&e, &owner);
+        }
+        storage::extend_vault_ttl(&e, &owner);
+    }
 }
 
 // --- Validation helpers ---

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -1431,3 +1431,144 @@ fn test_vc_count_zero_for_unknown_vault() {
     let stranger = Address::generate(&env);
     assert_eq!(client.vc_count(&stranger), 0);
 }
+
+// --- migrate_vc_index tests (issue #22) ---
+
+/// Write a legacy `VaultVCIds(owner)` entry as if produced by v0.1. The new
+/// O(1) index introduced in #20 has no public writer for this key, so tests
+/// that need to simulate a pre-upgrade vault drop into `env.as_contract` to
+/// populate it directly.
+fn seed_legacy_vault_vc_ids(env: &Env, contract_id: &Address, owner: &Address, ids: &[&str]) {
+    env.as_contract(contract_id, || {
+        let mut vec_ids = soroban_sdk::Vec::<String>::new(env);
+        for id in ids.iter() {
+            vec_ids.push_back(String::from_str(env, id));
+        }
+        let key = crate::storage::DataKey::VaultVCIds(owner.clone());
+        env.storage().persistent().set(&key, &vec_ids);
+    });
+}
+
+#[test]
+fn test_migrate_vc_index_moves_legacy_to_new_index() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+
+    // Simulate a v0.1 vault that has three vc_ids in the legacy Vec but no
+    // entries in the new index.
+    seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["vc-a", "vc-b", "vc-c"]);
+    assert_eq!(client.vc_count(&owner), 0);
+
+    client.migrate_vc_index(&owner);
+
+    // New index now has all three; legacy entry is gone.
+    assert_eq!(client.vc_count(&owner), 3);
+    let listed = client.list_vc_ids(&owner, &0_u32, &200_u32);
+    assert_eq!(listed.len(), 3);
+    assert!(listed.contains(String::from_str(&env, "vc-a")));
+    assert!(listed.contains(String::from_str(&env, "vc-b")));
+    assert!(listed.contains(String::from_str(&env, "vc-c")));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")] // VCSAlreadyMigrated
+fn test_migrate_vc_index_double_call_panics() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["vc-1"]);
+
+    client.migrate_vc_index(&owner);
+    // Second call: vc_count > 0 already, must reject.
+    client.migrate_vc_index(&owner);
+}
+
+#[test]
+fn test_migrate_vc_index_with_no_legacy_is_noop() {
+    // A vault created fresh post-upgrade has no legacy data and an empty new
+    // index. migrate_vc_index must complete without panicking.
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    assert_eq!(client.vc_count(&owner), 0);
+
+    client.migrate_vc_index(&owner);
+
+    // Still empty, no panic.
+    assert_eq!(client.vc_count(&owner), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")] // VCSAlreadyMigrated
+fn test_migrate_vc_index_panics_when_new_index_has_entries() {
+    // A vault that was created post-upgrade and already received VCs through
+    // the new index has nothing to migrate; calling migrate_vc_index must be
+    // rejected so callers can detect "already on the new schema" without
+    // pretending the call was successful.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-1"),
+        &String::from_str(&env, "<data>"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+    );
+    assert_eq!(client.vc_count(&owner), 1);
+
+    client.migrate_vc_index(&owner);
+}
+
+#[test]
+fn test_migrate_vc_index_requires_no_auth() {
+    // Migration is deterministic from on-chain state: any caller — not just
+    // the vault admin — can drive it. This test runs without
+    // env.mock_all_auths to confirm there is no `require_auth` on the path.
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let contract_id = env.register(VcVaultContract, ());
+    let client = VcVaultContractClient::new(&env, &contract_id);
+
+    // initialize and create_vault still need auths; mock just for those.
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["vc-1", "vc-2"]);
+
+    // Drop the auth mock so the next call would fail if any require_auth
+    // were inserted in the path.
+    env.set_auths(&[]);
+
+    client.migrate_vc_index(&owner);
+    assert_eq!(client.vc_count(&owner), 2);
+}
+
+#[test]
+fn test_migrate_vc_index_preserves_legacy_order() {
+    // The legacy Vec is enumerated in stored order and append_vc_to_index
+    // assigns positions 0..N in iteration order. After migration, listing
+    // from the new index returns the same sequence.
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["first", "second", "third"]);
+
+    client.migrate_vc_index(&owner);
+
+    let listed = client.list_vc_ids(&owner, &0_u32, &10_u32);
+    assert_eq!(listed.len(), 3);
+    assert_eq!(listed.get_unchecked(0), String::from_str(&env, "first"));
+    assert_eq!(listed.get_unchecked(1), String::from_str(&env, "second"));
+    assert_eq!(listed.get_unchecked(2), String::from_str(&env, "third"));
+}


### PR DESCRIPTION
Closes #22.

## Why

#20 changed the per-vault index from a single `Vec<String>` (`VaultVCIds(owner)`) to three O(1) keys (`VaultVCCount`, `VaultVCIndex`, `VaultVCPosition`). New issuances write to the new layout, but vaults that existed pre-upgrade still hold their vc_ids in the old Vec. The new helpers ignore that Vec, so:

- `list_vc_ids` returns an empty slice
- a fresh `issue()` starts the position counter from 0 — colliding with legacy positions

A migration entrypoint moves each legacy vc_id into the new layout and removes the old key.

## What

```rust
fn migrate_vc_index(owner: Address)
```

- **No auth required.** Migration is deterministic from on-chain state — it only relocates the same vc_ids — so any caller can drive it (the owner, an SDK background worker, a backend service). This avoids forcing the user to pay the migration cost on their next `issue()` call.
- Panics with `VCSAlreadyMigrated` when `vc_count > 0` (double call or post-v0.2 vault with new data).
- No-op when the vault has no legacy entry and the new index is empty (a clean v0.2 vault with zero VCs).
- Iterates the legacy Vec in stored order so `list_vc_ids` returns the same sequence post-migration.
- Removes `VaultVCIds(owner)` afterward and extends vault TTL.

## Tests

Six new tests:

- Successful migration moves three vc_ids into the new index and removes the legacy entry.
- Double-call panics with `VCSAlreadyMigrated`.
- Vault with no legacy data is a no-op (no panic).
- Post-upgrade vault that already has VCs in the new index panics with `VCSAlreadyMigrated` (catches misuse).
- No-auth: the call succeeds after `env.set_auths(&[])`.
- Legacy order is preserved in the new positions.

```
test result: ok. 83 passed; 0 failed
```