### PR TITLE
feat: batch_issue entrypoint up to 5 VCs

### DIFF
--- a/contracts/vc-vault/src/api/mod.rs
+++ b/contracts/vc-vault/src/api/mod.rs
@@ -45,6 +45,15 @@ pub trait VcVaultTrait {
         issuer_did: String,
         fee_override: i128,
     ) -> String;
+    fn batch_issue(
+        e: Env,
+        issuer: Address,
+        owner: Address,
+        vault_contract: Address,
+        issuer_did: String,
+        fee_override: i128,
+        vcs: Vec<(String, String)>,
+    ) -> Vec<String>;
     fn revoke(e: Env, owner: Address, vc_id: String, date: String);
     fn issue_linked(
         e: Env,

--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -377,6 +377,100 @@ impl VcVaultTrait for VcVaultContract {
         vc_id
     }
 
+    /// Issues up to `MAX_BATCH_SIZE` VCs into owner's vault in a single
+    /// transaction. Returns the issued vc_ids in input order.
+    ///
+    /// Compared to N sequential `issue()` calls this path:
+    ///
+    /// - takes one `issuer.require_auth()` for the whole batch,
+    /// - charges a single fee transfer of `fee_override × n` (when fees are
+    ///   enabled and `fee_override > 0`) instead of one per VC,
+    /// - extends the vault TTL once at the end,
+    /// - still emits a per-VC `VCIssued` event so off-chain indexers see
+    ///   each credential individually.
+    ///
+    /// Cap rationale: Soroban allows ~25 ledger entry writes per
+    /// transaction. Each VC writes 4 entries (`VaultVC`, `VaultVCIndex`,
+    /// `VaultVCPosition`, `VCStatus`) plus 1 shared `VaultVCCount`, so
+    /// `MAX_BATCH_SIZE = 5` lands at 21 entries with margin for the fee
+    /// transfer. Larger batches must be split client-side.
+    fn batch_issue(
+        e: Env,
+        issuer_addr: Address,
+        owner: Address,
+        vault_contract: Address,
+        issuer_did: String,
+        fee_override: i128,
+        vcs: Vec<(String, String)>,
+    ) -> Vec<String> {
+        issuer_addr.require_auth();
+        let n = vcs.len();
+        if n == 0 {
+            panic_with_error!(e, ContractError::BatchEmpty);
+        }
+        if n > storage::MAX_BATCH_SIZE {
+            panic_with_error!(e, ContractError::BatchTooLarge);
+        }
+        let this = e.current_contract_address();
+        if vault_contract != this {
+            panic_with_error!(e, ContractError::InvalidVaultContract);
+        }
+        validate_vault_active(&e, &owner);
+        ensure_issuer_authorized(&e, &owner, &issuer_addr);
+
+        // Single fee transfer for the entire batch, if enabled and the
+        // caller requested a positive override. The contract already trusts
+        // `issuer` to set fee_override per call (same as `issue`), so the
+        // batch behaves like N issues at the same per-VC fee.
+        if storage::read_fee_enabled(&e) && fee_override > 0 {
+            let fee_token = storage::read_fee_token_contract(&e);
+            let fee_dest = storage::read_fee_dest(&e);
+            // saturating_mul is safe: at MAX_BATCH_SIZE=5 and any plausible
+            // fee_override (≤ 10^16 stroops, the entire USDC supply order
+            // of magnitude), the product fits in i128 by ~22 orders of
+            // magnitude. The saturate-to-i128::MAX path would only fire
+            // under deliberately absurd inputs, where the token contract
+            // would reject the transfer for insufficient balance anyway.
+            let total = fee_override.saturating_mul(n as i128);
+            e.invoke_contract::<()>(
+                &fee_token,
+                &symbol_short!("transfer"),
+                (issuer_addr.clone(), fee_dest, total).into_val(&e),
+            );
+        }
+
+        // Issue each VC. Duplicate vc_ids — both within the batch and
+        // against existing entries — are caught by the existence check on
+        // the second iteration: the first write populates VaultVC and
+        // VCStatus, so the next attempt with the same id fails with
+        // VCAlreadyExists.
+        let mut result = Vec::new(&e);
+        for entry in vcs.iter() {
+            let (vc_id, vc_data) = entry;
+            if storage::read_vault_vc(&e, &owner, &vc_id).is_some()
+                || storage::read_vc_status(&e, &owner, &vc_id) != VCStatus::Invalid
+            {
+                panic_with_error!(e, ContractError::VCAlreadyExists);
+            }
+            vault::store_vc(
+                &e,
+                &owner,
+                vc_id.clone(),
+                vc_data,
+                this.clone(),
+                issuer_did.clone(),
+            );
+            storage::write_vc_status(&e, &owner, &vc_id, &VCStatus::Valid);
+            storage::extend_vc_ttl(&e, &owner, &vc_id);
+            events::vc_issued(&e, &owner, &vc_id, &issuer_addr);
+            result.push_back(vc_id);
+        }
+
+        // One vault TTL extend after all per-VC writes.
+        storage::extend_vault_ttl(&e, &owner);
+        result
+    }
+
     /// Revoke VC. Owner must sign. The VC payload remains queryable via
     /// `get_vc(owner, vc_id)`; only the active index entry is removed so the
     /// vault doesn't fill up with revoked entries (each free slot can be

--- a/contracts/vc-vault/src/error.rs
+++ b/contracts/vc-vault/src/error.rs
@@ -38,4 +38,8 @@ pub enum ContractError {
     VaultFull = 15,
     /// Pagination `limit` exceeds `MAX_LIST_LIMIT`.
     LimitTooLarge = 16,
+    /// Batch issuance request exceeds `MAX_BATCH_SIZE`.
+    BatchTooLarge = 17,
+    /// Batch issuance called with an empty `vcs` list.
+    BatchEmpty = 18,
 }

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -22,6 +22,14 @@ pub const MAX_VCS_PER_VAULT: u32 = 1_000;
 /// size their iteration.
 pub const MAX_LIST_LIMIT: u32 = 200;
 
+/// Maximum number of VCs that may be issued in a single `batch_issue` call.
+/// Each VC writes 4 ledger entries (`VaultVC`, `VaultVCIndex`,
+/// `VaultVCPosition`, `VCStatus`); plus 1 shared write to `VaultVCCount`.
+/// At the cap of 5 the batch touches 21 ledger entries, leaving headroom
+/// for the optional fee transfer (token, source-balance, dest-balance ≈ 3
+/// entries) under Soroban's ~25 entries-per-transaction default.
+pub const MAX_BATCH_SIZE: u32 = 5;
+
 /// Storage keys. Instance = admin, fees, flags. Persistent = vault metadata, VCs, status.
 #[derive(Clone)]
 #[contracttype]

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -3,7 +3,7 @@
 use crate::contract::{VcVaultContract, VcVaultContractClient};
 use crate::model::VCStatus;
 use soroban_sdk::{
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
     vec, Address, Env, IntoVal, String,
 };
 
@@ -1551,6 +1551,259 @@ fn test_migrate_vc_index_requires_no_auth() {
 
     client.migrate_vc_index(&owner);
     assert_eq!(client.vc_count(&owner), 2);
+}
+
+// --- batch_issue tests (issue #24) ---
+
+#[test]
+fn test_batch_issue_writes_all_vcs_in_order() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+
+    let id_a = String::from_str(&env, "vc-a");
+    let id_b = String::from_str(&env, "vc-b");
+    let id_c = String::from_str(&env, "vc-c");
+    let vcs = soroban_sdk::vec![
+        &env,
+        (id_a.clone(), data.clone()),
+        (id_b.clone(), data.clone()),
+        (id_c.clone(), data.clone()),
+    ];
+    let returned = client.batch_issue(&issuer, &owner, &contract_id, &issuer_did, &0_i128, &vcs);
+
+    assert_eq!(returned.len(), 3);
+    assert_eq!(returned.get_unchecked(0), id_a);
+    assert_eq!(returned.get_unchecked(1), id_b);
+    assert_eq!(returned.get_unchecked(2), id_c);
+    assert_eq!(client.vc_count(&owner), 3);
+    let listed = client.list_vc_ids(&owner, &0_u32, &10_u32);
+    assert!(listed.contains(id_a));
+    assert!(listed.contains(id_b));
+    assert!(listed.contains(id_c));
+}
+
+#[test]
+fn test_batch_issue_at_max_size_succeeds() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+
+    let vcs = soroban_sdk::vec![
+        &env,
+        (String::from_str(&env, "vc-1"), data.clone()),
+        (String::from_str(&env, "vc-2"), data.clone()),
+        (String::from_str(&env, "vc-3"), data.clone()),
+        (String::from_str(&env, "vc-4"), data.clone()),
+        (String::from_str(&env, "vc-5"), data.clone()),
+    ];
+    let returned = client.batch_issue(&issuer, &owner, &contract_id, &issuer_did, &0_i128, &vcs);
+    assert_eq!(returned.len(), 5);
+    assert_eq!(client.vc_count(&owner), 5);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #17)")] // BatchTooLarge
+fn test_batch_issue_above_max_size_panics() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let data = String::from_str(&env, "<data>");
+
+    let vcs = soroban_sdk::vec![
+        &env,
+        (String::from_str(&env, "vc-1"), data.clone()),
+        (String::from_str(&env, "vc-2"), data.clone()),
+        (String::from_str(&env, "vc-3"), data.clone()),
+        (String::from_str(&env, "vc-4"), data.clone()),
+        (String::from_str(&env, "vc-5"), data.clone()),
+        (String::from_str(&env, "vc-6"), data.clone()),
+    ];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")] // BatchEmpty
+fn test_batch_issue_empty_panics() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let vcs = soroban_sdk::Vec::<(String, String)>::new(&env);
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")] // VCAlreadyExists
+fn test_batch_issue_with_duplicate_within_batch_panics() {
+    // First entry writes vc-x; second entry's existence check finds it and
+    // panics with VCAlreadyExists.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let data = String::from_str(&env, "<data>");
+    let dup = String::from_str(&env, "vc-x");
+    let vcs = soroban_sdk::vec![&env, (dup.clone(), data.clone()), (dup, data),];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")] // VCAlreadyExists
+fn test_batch_issue_with_existing_vc_panics() {
+    // A VC with this id was previously issued; batch's existence check
+    // catches it on the first iteration.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    let data = String::from_str(&env, "<data>");
+
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-existing"),
+        &data,
+        &contract_id,
+        &issuer,
+        &issuer_did,
+        &0_i128,
+    );
+
+    let vcs = soroban_sdk::vec![
+        &env,
+        (String::from_str(&env, "vc-new"), data.clone()),
+        (String::from_str(&env, "vc-existing"), data),
+    ];
+    client.batch_issue(&issuer, &owner, &contract_id, &issuer_did, &0_i128, &vcs);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")] // VaultRevoked
+fn test_batch_issue_on_revoked_vault_panics() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    client.revoke_vault(&owner);
+    let data = String::from_str(&env, "<data>");
+    let vcs = soroban_sdk::vec![&env, (String::from_str(&env, "vc-1"), data),];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")] // InvalidVaultContract
+fn test_batch_issue_with_wrong_vault_contract_panics() {
+    let (env, admin, issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let wrong_contract = Address::generate(&env);
+    let data = String::from_str(&env, "<data>");
+    let vcs = soroban_sdk::vec![&env, (String::from_str(&env, "vc-1"), data),];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &wrong_contract,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+}
+
+#[test]
+fn test_batch_issue_emits_one_event_per_vc() {
+    // Off-chain indexers expect one VCIssued per credential, even when the
+    // credentials are written together. Capture events before any read so
+    // env.events().all() still holds them.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let data = String::from_str(&env, "<data>");
+    let vcs = soroban_sdk::vec![
+        &env,
+        (String::from_str(&env, "vc-a"), data.clone()),
+        (String::from_str(&env, "vc-b"), data.clone()),
+        (String::from_str(&env, "vc-c"), data),
+    ];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+    // 3 VCIssued events from the batch (no other contract calls between).
+    assert_eq!(env.events().all().len(), 3);
+}
+
+#[test]
+fn test_batch_issue_auto_authorizes_unknown_issuer() {
+    // Mirrors single issue() semantics: if the issuer is not yet on the
+    // vault's authorized list and not in the denied list, batch_issue
+    // auto-authorizes them.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    // No explicit authorize_issuer call.
+    let data = String::from_str(&env, "<data>");
+    let vcs = soroban_sdk::vec![&env, (String::from_str(&env, "vc-1"), data),];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+    assert_eq!(client.vc_count(&owner), 1);
 }
 
 #[test]


### PR DESCRIPTION
Closes #24.

## Why

Issuers like BAF (130+ credentials per builder cohort) currently pay one transaction fee per credential because `issue` is single-VC. Mass issuance needs an entrypoint that reuses authorization, fee transfer, and TTL extension across multiple VCs.

## What

```rust
fn batch_issue(
    issuer: Address,
    owner: Address,
    vault_contract: Address,
    issuer_did: String,
    fee_override: i128,
    vcs: Vec<(String, String)>,  // (vc_id, vc_data) pairs
) -> Vec<String>
```

- **Single `issuer.require_auth()`** for the whole batch
- **Single fee transfer** of `fee_override × n` (when fees enabled and `fee_override > 0`)
- **Single `extend_vault_ttl`** after all per-VC writes
- **Per-VC `VCIssued` event** so off-chain indexers see each credential individually
- **Auto-authorizes** an unknown issuer just like `issue`
- Returns the issued `vc_ids` in input order

### Cap: `MAX_BATCH_SIZE = 5`

Each VC writes 4 ledger entries (`VaultVC`, `VaultVCIndex`, `VaultVCPosition`, `VCStatus`). At 5 VCs that's 20 + 1 shared `VaultVCCount` = 21, leaving ~4 entries of margin for the fee transfer under Soroban's ~25 entries-per-transaction default. Larger volumes are split client-side: 130 VCs → 26 batched txs vs. 130 individual txs.

### New errors

| Code | Name | Trigger |
|---|---|---|
| 17 | `BatchTooLarge` | `vcs.len() > MAX_BATCH_SIZE` |
| 18 | `BatchEmpty` | `vcs.len() == 0` |

## Tests

10 new tests:

- writes all VCs in input order
- batch of exactly 5 succeeds
- batch of 6 → `BatchTooLarge`
- empty batch → `BatchEmpty`
- duplicate `vc_id` within batch → `VCAlreadyExists`
- duplicate against pre-existing VC → `VCAlreadyExists`
- revoked vault → `VaultRevoked`
- wrong vault contract → `InvalidVaultContract`
- emits one `VCIssued` per VC
- auto-authorizes unknown issuer (parity with `issue`)

```
test result: ok. 93 passed; 0 failed
```

## Capacity impact

| Operation | Cost (5 VCs) | Notes |
|---|---|---|
| 5 × `issue()` (5 txs) | 5 × ~150k instr + 5 × tx fee + 5 × fee transfer | ~750k instr total + 5 tx overhead |
| 1 × `batch_issue(5)` | ~750k instr + 1 tx fee + 1 fee transfer | Same instructions but ~5× cheaper for the issuer |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch issuance capability to issue multiple VCs in a single transaction with a maximum of 5 VCs per batch.
  * Single authentication required for batch operations with consolidated fee handling.

* **Tests**
  * Added comprehensive test coverage for batch issuance including validation, error scenarios, and event emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->