### PR TITLE
chore: release vc-vault v0.2.0 to testnet

### DIFF
--- a/contracts/vc-vault/Cargo.toml
+++ b/contracts/vc-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vc-vault-contract"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/docs/deployments/testnet.md
+++ b/docs/deployments/testnet.md
@@ -16,3 +16,4 @@ RPC: `https://soroban-testnet.stellar.org:443`
 | Version | Contract ID | Date | Notes |
 |---|---|---|---|
 | 0.1.0 | `CC3SQ7UTAQQDQF6PUQMQIGK3BMPB22OKMHE5Y5XELEX3JFAKC72SQOAM` | 2026-05-06 | Tranche 1 initial deploy |
+| 0.2.0 | `CBXC6LXBY5FGEG46VZ4AJ2AH2EJBINBA7BMILIEO4EJYI6ZTY7K7J5D5` | 2026-05-07 | SOW D2: O(1) index + pagination + migrate + batch_issue. WASM hash `c8da61dd3dd46b2810a743d50a388c09a00f0b7e8e2df7ceb5a71c8ce5dc4dd8`. |


### PR DESCRIPTION
Closes #23.

Bumps vc-vault-contract version from 0.1.0 to 0.2.0 and records the new testnet deployment.

Contract ID:  CBXC6LXBY5FGEG46VZ4AJ2AH2EJBINBA7BMILIEO4EJYI6ZTY7K7J5D5
WASM hash:    c8da61dd3dd46b2810a743d50a388c09a00f0b7e8e2df7ceb5a71c8ce5dc4dd8

The v0.1.0 entry stays in docs/deployments/testnet.md as historical record. 

Tests: 93 passed. WASM 44188 bytes (optimized).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.2.0 of vc-vault-contract to testnet, including updates from SOW D2 specification (deployed on 2026-05-07).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->