### PR TITLE
feat: cap user-controlled input lengths to prevent DoS

### DIFF
--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -135,6 +135,7 @@ impl VcVaultTrait for VcVaultContract {
     }
 
     fn create_vault(e: Env, owner: Address, did_uri: String) {
+        require_did_uri_len(&e, &did_uri);
         if !storage::has_contract_admin(&e) {
             panic_with_error!(e, ContractError::NotInitialized);
         }
@@ -162,6 +163,7 @@ impl VcVaultTrait for VcVaultContract {
 
     /// Replace full issuer list. Vault admin only.
     fn authorize_issuers(e: Env, owner: Address, issuers: Vec<Address>) {
+        require_issuers_list_len(&e, &issuers);
         validate_vault_admin(&e, &owner);
         validate_vault_active(&e, &owner);
         vault::authorize_issuers(&e, &owner, &issuers);
@@ -248,6 +250,7 @@ impl VcVaultTrait for VcVaultContract {
         owner: Address,
         vc_id: String,
     ) -> Option<crate::model::VerifiableCredential> {
+        require_vc_id_len(&e, &vc_id);
         storage::extend_vault_ttl(&e, &owner);
         let vc = storage::read_vault_vc(&e, &owner, &vc_id);
         if vc.is_some() {
@@ -258,6 +261,7 @@ impl VcVaultTrait for VcVaultContract {
 
     /// Verify VC status. Returns VCStatus::Valid, VCStatus::Revoked(date), or VCStatus::Invalid.
     fn verify_vc(e: Env, owner: Address, vc_id: String) -> VCStatus {
+        require_vc_id_len(&e, &vc_id);
         storage::extend_vault_ttl(&e, &owner);
         let vc_opt = storage::read_vault_vc(&e, &owner, &vc_id);
         if vc_opt.is_none() {
@@ -278,6 +282,7 @@ impl VcVaultTrait for VcVaultContract {
 
     /// Moves a Valid VC from one vault to another; source owner and an authorized issuer must sign.
     fn push(e: Env, from_owner: Address, to_owner: Address, vc_id: String, issuer_addr: Address) {
+        require_vc_id_len(&e, &vc_id);
         validate_vault_active(&e, &from_owner);
         validate_vault_active(&e, &to_owner);
         from_owner.require_auth();
@@ -344,6 +349,9 @@ impl VcVaultTrait for VcVaultContract {
         issuer_did: String,
         fee_override: i128,
     ) -> String {
+        require_vc_id_len(&e, &vc_id);
+        require_vc_data_len(&e, &vc_data);
+        require_issuer_did_len(&e, &issuer_did);
         issuer_addr.require_auth();
         let this = e.current_contract_address();
         if vault_contract != this {
@@ -403,6 +411,14 @@ impl VcVaultTrait for VcVaultContract {
         fee_override: i128,
         vcs: Vec<(String, String)>,
     ) -> Vec<String> {
+        require_issuer_did_len(&e, &issuer_did);
+        // Validate every (vc_id, vc_data) pair up front so an oversize entry
+        // late in the batch doesn't waste CPU on the earlier valid ones.
+        for entry in vcs.iter() {
+            let (vc_id, vc_data) = entry;
+            require_vc_id_len(&e, &vc_id);
+            require_vc_data_len(&e, &vc_data);
+        }
         issuer_addr.require_auth();
         let n = vcs.len();
         if n == 0 {
@@ -477,6 +493,8 @@ impl VcVaultTrait for VcVaultContract {
     /// reissued under a new vc_id, preserving the `MAX_VCS_PER_VAULT` cap as
     /// a *concurrent active* limit).
     fn revoke(e: Env, owner: Address, vc_id: String, date: String) {
+        require_vc_id_len(&e, &vc_id);
+        require_date_len(&e, &date);
         owner.require_auth();
         // VC must exist in this vault (not pushed away) and must not have been
         // revoked already. Checking vault_vc guards against the pushed-away case
@@ -514,6 +532,10 @@ impl VcVaultTrait for VcVaultContract {
         parent_owner: Address,
         parent_vc_id: String,
     ) {
+        require_vc_id_len(&e, &vc_id);
+        require_vc_data_len(&e, &data);
+        require_issuer_did_len(&e, &issuer_did);
+        require_vc_id_len(&e, &parent_vc_id);
         issuer.require_auth();
         let this = e.current_contract_address();
         if issuance_contract != this {
@@ -553,6 +575,7 @@ impl VcVaultTrait for VcVaultContract {
     /// Returns Some((parent_owner, parent_vc_id)) if the VC was issued via issue_linked,
     /// or None if it is a regular VC with no parent link.
     fn get_vc_parent(e: Env, owner: Address, vc_id: String) -> Option<(Address, String)> {
+        require_vc_id_len(&e, &vc_id);
         storage::extend_instance_ttl(&e);
         storage::read_vc_parent(&e, &owner, &vc_id)
     }
@@ -561,6 +584,7 @@ impl VcVaultTrait for VcVaultContract {
 
     /// Creates a vault on behalf of owner; sponsor must sign and be authorized unless open_to_all is enabled.
     fn create_sponsored_vault(e: Env, sponsor: Address, owner: Address, did_uri: String) {
+        require_did_uri_len(&e, &did_uri);
         sponsor.require_auth();
         if !storage::has_contract_admin(&e) {
             panic_with_error!(e, ContractError::NotInitialized);
@@ -745,4 +769,47 @@ fn store_vc_payload(
         }
     }
     vault::store_vc(e, owner, vc_id, vc_data, issuance_contract, issuer_did);
+}
+
+// --- Input length validators ---
+//
+// Each public entrypoint that accepts user-controlled strings calls these
+// before doing any storage I/O. Violations panic with `InputTooLong` so the
+// transaction reverts before the contract spends instructions hashing or
+// indexing oversized payloads.
+
+fn require_vc_id_len(e: &Env, vc_id: &String) {
+    if vc_id.len() > storage::MAX_VC_ID_LEN {
+        panic_with_error!(e, ContractError::InputTooLong);
+    }
+}
+
+fn require_vc_data_len(e: &Env, vc_data: &String) {
+    if vc_data.len() > storage::MAX_VC_DATA_LEN {
+        panic_with_error!(e, ContractError::InputTooLong);
+    }
+}
+
+fn require_did_uri_len(e: &Env, did_uri: &String) {
+    if did_uri.len() > storage::MAX_DID_URI_LEN {
+        panic_with_error!(e, ContractError::InputTooLong);
+    }
+}
+
+fn require_issuer_did_len(e: &Env, issuer_did: &String) {
+    if issuer_did.len() > storage::MAX_ISSUER_DID_LEN {
+        panic_with_error!(e, ContractError::InputTooLong);
+    }
+}
+
+fn require_date_len(e: &Env, date: &String) {
+    if date.len() > storage::MAX_DATE_LEN {
+        panic_with_error!(e, ContractError::InputTooLong);
+    }
+}
+
+fn require_issuers_list_len(e: &Env, issuers: &Vec<Address>) {
+    if issuers.len() > storage::MAX_ISSUERS_LIST {
+        panic_with_error!(e, ContractError::IssuerListTooLong);
+    }
 }

--- a/contracts/vc-vault/src/error.rs
+++ b/contracts/vc-vault/src/error.rs
@@ -42,4 +42,9 @@ pub enum ContractError {
     BatchTooLarge = 17,
     /// Batch issuance called with an empty `vcs` list.
     BatchEmpty = 18,
+    /// String input exceeds its per-field maximum length (vc_id, vc_data,
+    /// did_uri, issuer_did, or date).
+    InputTooLong = 19,
+    /// `authorize_issuers` called with a list larger than `MAX_ISSUERS_LIST`.
+    IssuerListTooLong = 20,
 }

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -30,6 +30,36 @@ pub const MAX_LIST_LIMIT: u32 = 200;
 /// entries) under Soroban's ~25 entries-per-transaction default.
 pub const MAX_BATCH_SIZE: u32 = 5;
 
+// --- Per-field input length caps ---
+//
+// Caps user-controlled string inputs at every write entrypoint to bound
+// storage rent and CPU cost. Reads that take a vc_id are also capped so an
+// attacker can't force the contract to spend instructions on a 1MB key
+// before the lookup misses.
+//
+// Numbers chosen with a 4-10× safety margin over realistic values:
+// - vc_id: typical UUIDs are 36 chars; 64 covers prefixed schemes like
+//   `urn:uuid:...`.
+// - vc_data: encrypted credential payloads typically 1-5KB; 10KB allows
+//   complex schemas without inviting state bloat.
+// - did_uri / issuer_did: longest realistic DIDs (`did:pkh:stellar:...:G...`)
+//   are ~60 chars; 256 is a comfortable upper bound aligned with the
+//   did:stellar v0.1 spec.
+// - date: ISO 8601 timestamps are 20-30 chars; 64 is sufficient.
+
+/// Maximum bytes for `vc_id` strings.
+pub const MAX_VC_ID_LEN: u32 = 64;
+/// Maximum bytes for `vc_data` payloads.
+pub const MAX_VC_DATA_LEN: u32 = 10_000;
+/// Maximum bytes for vault `did_uri`.
+pub const MAX_DID_URI_LEN: u32 = 256;
+/// Maximum bytes for `issuer_did`.
+pub const MAX_ISSUER_DID_LEN: u32 = 256;
+/// Maximum bytes for revocation `date` strings (ISO 8601).
+pub const MAX_DATE_LEN: u32 = 64;
+/// Maximum number of addresses accepted by `authorize_issuers(list)`.
+pub const MAX_ISSUERS_LIST: u32 = 100;
+
 /// Storage keys. Instance = admin, fees, flags. Persistent = vault metadata, VCs, status.
 #[derive(Clone)]
 #[contracttype]

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2033,3 +2033,51 @@ fn test_get_vc_rejects_oversized_vc_id() {
     let vc_id = long_string(&env, b'q', 65);
     client.get_vc(&owner, &vc_id);
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")] // IssuerListTooLong
+fn test_authorize_issuer_rejects_when_list_at_cap() {
+    // Cap must apply to single-add too, not just the bulk replace path.
+    // Fill the list to MAX_ISSUERS_LIST=100 via authorize_issuers (which is
+    // capped at exactly that count), then authorize_issuer one more — must
+    // panic with IssuerListTooLong instead of silently growing past the cap.
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let mut issuers = soroban_sdk::Vec::<Address>::new(&env);
+    for _ in 0..100 {
+        issuers.push_back(Address::generate(&env));
+    }
+    client.authorize_issuers(&owner, &issuers);
+    let extra = Address::generate(&env);
+    client.authorize_issuer(&owner, &extra);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")] // IssuerListTooLong
+fn test_issue_rejects_auto_authorization_when_list_at_cap() {
+    // Auto-authorization inside ensure_issuer_authorized is the silent
+    // growth path CodeRabbit flagged: an attacker could spam issue() from
+    // many fresh addresses to grow VaultIssuers past the cap. The fix moves
+    // the cap check into vault::authorize_issuer, which fires on this path.
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let mut issuers = soroban_sdk::Vec::<Address>::new(&env);
+    for _ in 0..100 {
+        issuers.push_back(Address::generate(&env));
+    }
+    client.authorize_issuers(&owner, &issuers);
+    let attacker = Address::generate(&env);
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-1"),
+        &String::from_str(&env, "<data>"),
+        &contract_id,
+        &attacker,
+        &String::from_str(&env, "did:attacker"),
+        &0_i128,
+    );
+}

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -1037,7 +1037,7 @@ fn test_push_revoked_vc_returns_already_revoked_error() {
     client.push(&from_owner, &to_owner, &vc_id, &issuer);
 }
 
-// --- O(1) index tests (issue #20) ---
+// --- O(1) index tests ---
 
 #[test]
 fn test_index_remove_middle_uses_swap_and_pop() {
@@ -1272,7 +1272,7 @@ fn test_index_remains_consistent_after_many_issues_and_revokes() {
     }
 }
 
-// --- Pagination tests (issue #21) ---
+// --- Pagination tests ---
 
 #[test]
 fn test_vc_count_is_zero_for_empty_vault() {
@@ -1432,7 +1432,7 @@ fn test_vc_count_zero_for_unknown_vault() {
     assert_eq!(client.vc_count(&stranger), 0);
 }
 
-// --- migrate_vc_index tests (issue #22) ---
+// --- migrate_vc_index tests ---
 
 /// Write a legacy `VaultVCIds(owner)` entry as if produced by v0.1. The new
 /// O(1) index introduced in #20 has no public writer for this key, so tests
@@ -1553,7 +1553,7 @@ fn test_migrate_vc_index_requires_no_auth() {
     assert_eq!(client.vc_count(&owner), 2);
 }
 
-// --- batch_issue tests (issue #24) ---
+// --- batch_issue tests ---
 
 #[test]
 fn test_batch_issue_writes_all_vcs_in_order() {
@@ -1824,4 +1824,212 @@ fn test_migrate_vc_index_preserves_legacy_order() {
     assert_eq!(listed.get_unchecked(0), String::from_str(&env, "first"));
     assert_eq!(listed.get_unchecked(1), String::from_str(&env, "second"));
     assert_eq!(listed.get_unchecked(2), String::from_str(&env, "third"));
+}
+
+// --- Input length cap tests ---
+//
+// Each cap is enforced at every entrypoint that accepts the field, so the
+// tests pick the entrypoint where each input first reaches the contract:
+// `vc_id` and `vc_data` via issue(), `did_uri` via create_vault(),
+// `issuer_did` via issue(), `date` via revoke(), and the issuers-list
+// length via authorize_issuers().
+//
+// Strings exactly at the cap must succeed; one byte over must panic with
+// InputTooLong (#19) — except for the issuer-list cap, which uses
+// IssuerListTooLong (#20).
+
+fn long_string(env: &Env, byte: u8, n: usize) -> String {
+    extern crate alloc;
+    let v: alloc::vec::Vec<u8> = (0..n).map(|_| byte).collect();
+    String::from_bytes(env, &v)
+}
+
+#[test]
+fn test_create_vault_accepts_did_uri_at_max_len() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    let did_uri = long_string(&env, b'd', 256); // MAX_DID_URI_LEN
+    client.create_vault(&owner, &did_uri);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_create_vault_rejects_did_uri_over_max_len() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    let did_uri = long_string(&env, b'd', 257);
+    client.create_vault(&owner, &did_uri);
+}
+
+#[test]
+fn test_issue_accepts_vc_id_at_max_len() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let vc_id = long_string(&env, b'a', 64); // MAX_VC_ID_LEN
+    client.issue(
+        &owner,
+        &vc_id,
+        &String::from_str(&env, "<data>"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+    );
+    assert_eq!(client.vc_count(&owner), 1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_issue_rejects_vc_id_over_max_len() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let vc_id = long_string(&env, b'a', 65);
+    client.issue(
+        &owner,
+        &vc_id,
+        &String::from_str(&env, "<data>"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_issue_rejects_vc_data_over_max_len() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    // MAX_VC_DATA_LEN is 10_000; 10_001 bytes must reject.
+    let vc_data = long_string(&env, b'd', 10_001);
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-1"),
+        &vc_data,
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_issue_rejects_issuer_did_over_max_len() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let issuer_did = long_string(&env, b'i', 257);
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-1"),
+        &String::from_str(&env, "<data>"),
+        &contract_id,
+        &issuer,
+        &issuer_did,
+        &0_i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_revoke_rejects_date_over_max_len() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let vc_id = String::from_str(&env, "vc-1");
+    client.issue(
+        &owner,
+        &vc_id,
+        &String::from_str(&env, "<data>"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+    );
+    let date = long_string(&env, b'X', 65); // MAX_DATE_LEN = 64
+    client.revoke(&owner, &vc_id, &date);
+}
+
+#[test]
+fn test_authorize_issuers_accepts_max_list_size() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let mut issuers = soroban_sdk::Vec::<Address>::new(&env);
+    for _ in 0..100 {
+        // MAX_ISSUERS_LIST
+        issuers.push_back(Address::generate(&env));
+    }
+    client.authorize_issuers(&owner, &issuers);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")] // IssuerListTooLong
+fn test_authorize_issuers_rejects_oversized_list() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let mut issuers = soroban_sdk::Vec::<Address>::new(&env);
+    for _ in 0..101 {
+        issuers.push_back(Address::generate(&env));
+    }
+    client.authorize_issuers(&owner, &issuers);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_batch_issue_rejects_oversized_vc_id_within_batch() {
+    // The cap applies inside batch_issue too: even if 4 entries are valid, a
+    // 5th oversize id rejects the whole batch.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let data = String::from_str(&env, "<data>");
+    let bad_id = long_string(&env, b'z', 65);
+    let vcs = soroban_sdk::vec![
+        &env,
+        (String::from_str(&env, "vc-1"), data.clone()),
+        (bad_id, data),
+    ];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+        &vcs,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")] // InputTooLong
+fn test_get_vc_rejects_oversized_vc_id() {
+    // Read paths cap the input too so an attacker can't force the contract
+    // to spend instructions hashing a 1MB key before the lookup misses.
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let vc_id = long_string(&env, b'q', 65);
+    client.get_vc(&owner, &vc_id);
 }

--- a/contracts/vc-vault/src/vault/issuer.rs
+++ b/contracts/vc-vault/src/vault/issuer.rs
@@ -5,10 +5,22 @@ use crate::storage;
 use soroban_sdk::{panic_with_error, Address, Env, Vec};
 
 /// Adds an issuer to the vault's authorized list; panics if already present.
+///
+/// Enforces `MAX_ISSUERS_LIST` here rather than at the entrypoint so the cap
+/// covers every growth path:
+///   - direct `authorize_issuer(owner, issuer)` calls
+///   - auto-authorization triggered by `issue` / `batch_issue` /
+///     `issue_linked` via `ensure_issuer_authorized`
+///
+/// `authorize_issuers(list)` is checked at its entrypoint instead because it
+/// fully replaces the stored list (the cap on the new list is what matters).
 pub fn authorize_issuer(e: &Env, owner: &Address, issuer: &Address) {
     let mut issuers: Vec<Address> = storage::read_vault_issuers(e, owner);
     if is_authorized(&issuers, issuer) {
         panic_with_error!(e, ContractError::IssuerAlreadyAuthorized)
+    }
+    if issuers.len() >= storage::MAX_ISSUERS_LIST {
+        panic_with_error!(e, ContractError::IssuerListTooLong)
     }
     issuers.push_front(issuer.clone());
     storage::write_vault_issuers(e, owner, &issuers);


### PR DESCRIPTION
Closes #25.

## Why

Every public entrypoint that accepts a user-controlled string or unbounded list previously had no length validation. A malicious or buggy caller could submit megabyte-sized `vc_data`, `did_uri`, or a 10,000-address `authorize_issuers` list, inflating storage rent and costing legitimate readers extra CPU on every list/lookup.

## Caps

| Field | Limit | Realistic value |
|---|---|---|
| `vc_id` | 64 bytes | UUIDs are 36 chars |
| `vc_data` | 10,000 bytes | encrypted payloads typically 1-5 KB |
| `did_uri` | 256 bytes | longest `did:stellar:...` is ~60 chars |
| `issuer_did` | 256 bytes | same shape as `did_uri` |
| `date` | 64 bytes | ISO 8601 is 20-30 chars |
| `authorize_issuers(list)` | 100 entries | typical vault has < 20 issuers |

Each cap is 4-10× the largest realistic value, so it bites only on adversarial or buggy callers — never on real flows.

## New error codes

| Code | Name | Trigger |
|---|---|---|
| 19 | `InputTooLong` | oversize string in any entrypoint |
| 20 | `IssuerListTooLong` | `authorize_issuers` called with > 100 entries |

## Coverage

Caps apply at **every** entrypoint that accepts the relevant input, including read paths (`get_vc`, `verify_vc`, `get_vc_parent`, `push`) so a caller can't force the contract to spend instructions hashing a 1 MB key before the lookup misses.

Specifically:

- **Write paths**: `create_vault`, `create_sponsored_vault`, `issue`, `batch_issue`, `issue_linked`, `revoke`, `authorize_issuers`, `push`
- **Read paths with `vc_id` input**: `get_vc`, `verify_vc`, `get_vc_parent`

## Tests

11 new tests:

- `create_vault` accepts `did_uri` at the cap, rejects over
- `issue` accepts `vc_id` at the cap, rejects over
- `issue` rejects oversize `vc_data`
- `issue` rejects oversize `issuer_did`
- `revoke` rejects oversize `date`
- `authorize_issuers` accepts list at the cap, rejects over
- `batch_issue` rejects oversize `vc_id` within the batch
- `get_vc` rejects oversize `vc_id`

```
test result: ok. 104 passed; 0 failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input size validation now enforced for all user-submitted data fields (VC IDs, payloads, DIDs, dates, and issuer lists)
  * New error codes for oversized input rejections

* **Tests**
  * Expanded coverage to verify validation boundaries across all contract entry points

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ACTA-Team/contracts-acta/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->