### PR TITLE
feat: emit events on remaining state transitions

### DIFF
--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -36,14 +36,16 @@ impl VcVaultTrait for VcVaultContract {
         storage::write_contract_admin(&e, &contract_admin);
         storage::write_fee_enabled(&e, &false);
         storage::extend_instance_ttl(&e);
+        events::contract_initialized(&e, &contract_admin);
     }
 
     /// Nominate a new contract admin. Current admin must sign.
     /// The nominee must call accept_contract_admin to complete the transfer.
     fn nominate_admin(e: Env, new_admin: Address) {
-        let _ = validate_contract_admin(&e);
+        let current = validate_contract_admin(&e);
         storage::write_pending_admin(&e, &new_admin);
         storage::extend_instance_ttl(&e);
+        events::admin_nominated(&e, &current, &new_admin);
     }
 
     /// Accept a pending admin nomination. Nominee must sign.
@@ -53,9 +55,13 @@ impl VcVaultTrait for VcVaultContract {
             None => panic_with_error!(e, ContractError::NoPendingAdmin),
         };
         pending.require_auth();
+        // Capture the outgoing admin before overwriting so the event carries both
+        // sides of the transfer.
+        let old_admin = storage::read_contract_admin(&e);
         storage::write_contract_admin(&e, &pending);
         storage::remove_pending_admin(&e);
         storage::extend_instance_ttl(&e);
+        events::admin_transferred(&e, &old_admin, &pending);
     }
 
     /// Configure fee: token, destination, amount. Admin only.
@@ -65,6 +71,7 @@ impl VcVaultTrait for VcVaultContract {
         storage::write_fee_dest(&e, &fee_dest);
         storage::write_fee_amount(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
+        events::fee_config_set(&e, &token_contract, &fee_dest, fee_amount);
     }
 
     /// Enable or disable fee charging on issue. Admin only.
@@ -72,30 +79,35 @@ impl VcVaultTrait for VcVaultContract {
         validate_contract_admin(&e);
         storage::write_fee_enabled(&e, &enabled);
         storage::extend_instance_ttl(&e);
+        events::fee_enabled_changed(&e, enabled);
     }
 
     fn set_fee_admin(e: Env, fee_amount: i128) {
         validate_contract_admin(&e);
         storage::write_fee_admin(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
+        events::fee_admin_set(&e, fee_amount);
     }
 
     fn set_fee_standard(e: Env, fee_amount: i128) {
         validate_contract_admin(&e);
         storage::write_fee_standard(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
+        events::fee_standard_set(&e, fee_amount);
     }
 
     fn set_fee_early(e: Env, fee_amount: i128) {
         validate_contract_admin(&e);
         storage::write_fee_early(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
+        events::fee_early_set(&e, fee_amount);
     }
 
     fn set_fee_custom(e: Env, issuer: Address, fee_amount: i128) {
         validate_contract_admin(&e);
         storage::write_fee_custom(&e, &issuer, &fee_amount);
         storage::extend_instance_ttl(&e);
+        events::fee_custom_set(&e, &issuer, fee_amount);
     }
 
     fn get_fee_admin(e: Env) -> i128 {
@@ -122,6 +134,7 @@ impl VcVaultTrait for VcVaultContract {
     fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
         validate_contract_admin(&e);
         storage::extend_instance_ttl(&e);
+        events::contract_upgraded(&e, &new_wasm_hash);
         e.deployer().update_current_contract_wasm(new_wasm_hash);
     }
 
@@ -612,6 +625,7 @@ impl VcVaultTrait for VcVaultContract {
         validate_contract_admin(&e);
         storage::write_sponsored_vault_open_to_all(&e, &open);
         storage::extend_instance_ttl(&e);
+        events::sponsor_open_to_all_changed(&e, open);
     }
 
     /// Query whether sponsored vault creation is open to all.
@@ -625,6 +639,7 @@ impl VcVaultTrait for VcVaultContract {
         validate_contract_admin(&e);
         storage::add_sponsored_vault_sponsor(&e, &sponsor);
         storage::extend_instance_ttl(&e);
+        events::sponsor_added(&e, &sponsor);
     }
 
     /// Remove an address from the authorized sponsors list. Admin only.
@@ -632,6 +647,7 @@ impl VcVaultTrait for VcVaultContract {
         validate_contract_admin(&e);
         storage::remove_sponsored_vault_sponsor(&e, &sponsor);
         storage::extend_instance_ttl(&e);
+        events::sponsor_removed(&e, &sponsor);
     }
 
     // --- Migrations ---
@@ -655,6 +671,7 @@ impl VcVaultTrait for VcVaultContract {
         }
         storage::remove_legacy_vault_vcs(&e, &owner);
         storage::extend_vault_ttl(&e, &owner);
+        events::vault_migrated(&e, &owner);
     }
 
     /// Migrate the v0.1 `Vec<String>` index at `VaultVCIds(owner)` into the
@@ -681,6 +698,11 @@ impl VcVaultTrait for VcVaultContract {
             panic_with_error!(e, ContractError::VCSAlreadyMigrated);
         }
         let legacy_ids = storage::read_legacy_vault_vc_ids(&e, &owner);
+        // Capture the count up front so the event reports the exact number
+        // moved — append_vc_to_index increments VaultVCCount on every call,
+        // so reading it after the loop would also work, but the explicit
+        // pre-loop read is unambiguous about intent.
+        let migrated_count = legacy_ids.len();
         for vc_id in legacy_ids.iter() {
             storage::append_vc_to_index(&e, &owner, &vc_id);
         }
@@ -688,6 +710,7 @@ impl VcVaultTrait for VcVaultContract {
             storage::remove_legacy_vault_vc_ids(&e, &owner);
         }
         storage::extend_vault_ttl(&e, &owner);
+        events::vault_index_migrated(&e, &owner, migrated_count);
     }
 }
 

--- a/contracts/vc-vault/src/events/mod.rs
+++ b/contracts/vc-vault/src/events/mod.rs
@@ -1,6 +1,6 @@
 //! Contract events. Published on key state transitions for on-chain observability.
 
-use soroban_sdk::{contractevent, Address, Env, String};
+use soroban_sdk::{contractevent, Address, BytesN, Env, String};
 
 #[contractevent]
 pub struct VaultCreated {
@@ -159,6 +159,193 @@ pub fn linked_vc_issued(
         vc_id: vc_id.clone(),
         parent_owner: parent_owner.clone(),
         parent_vc_id: parent_vc_id.clone(),
+    }
+    .publish(e);
+}
+
+// --- Admin / governance events ---
+
+#[contractevent]
+pub struct ContractInitialized {
+    pub admin: Address,
+}
+
+#[contractevent]
+pub struct AdminNominated {
+    pub current_admin: Address,
+    pub nominee: Address,
+}
+
+#[contractevent]
+pub struct AdminTransferred {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+#[contractevent]
+pub struct ContractUpgraded {
+    pub new_wasm_hash: BytesN<32>,
+}
+
+// --- Fee config events ---
+
+#[contractevent]
+pub struct FeeEnabledChanged {
+    pub enabled: bool,
+}
+
+#[contractevent]
+pub struct FeeConfigSet {
+    pub token_contract: Address,
+    pub fee_dest: Address,
+    pub fee_amount: i128,
+}
+
+#[contractevent]
+pub struct FeeAdminSet {
+    pub amount: i128,
+}
+
+#[contractevent]
+pub struct FeeStandardSet {
+    pub amount: i128,
+}
+
+#[contractevent]
+pub struct FeeEarlySet {
+    pub amount: i128,
+}
+
+#[contractevent]
+pub struct FeeCustomSet {
+    pub issuer: Address,
+    pub amount: i128,
+}
+
+// --- Sponsor events ---
+
+#[contractevent]
+pub struct SponsorOpenToAllChanged {
+    pub open: bool,
+}
+
+#[contractevent]
+pub struct SponsorAdded {
+    pub sponsor: Address,
+}
+
+#[contractevent]
+pub struct SponsorRemoved {
+    pub sponsor: Address,
+}
+
+// --- Migration events ---
+
+#[contractevent]
+pub struct VaultMigrated {
+    pub owner: Address,
+}
+
+#[contractevent]
+pub struct VaultIndexMigrated {
+    pub owner: Address,
+    pub migrated_count: u32,
+}
+
+// --- Publishers ---
+
+pub fn contract_initialized(e: &Env, admin: &Address) {
+    ContractInitialized {
+        admin: admin.clone(),
+    }
+    .publish(e);
+}
+
+pub fn admin_nominated(e: &Env, current_admin: &Address, nominee: &Address) {
+    AdminNominated {
+        current_admin: current_admin.clone(),
+        nominee: nominee.clone(),
+    }
+    .publish(e);
+}
+
+pub fn admin_transferred(e: &Env, old_admin: &Address, new_admin: &Address) {
+    AdminTransferred {
+        old_admin: old_admin.clone(),
+        new_admin: new_admin.clone(),
+    }
+    .publish(e);
+}
+
+pub fn contract_upgraded(e: &Env, new_wasm_hash: &BytesN<32>) {
+    ContractUpgraded {
+        new_wasm_hash: new_wasm_hash.clone(),
+    }
+    .publish(e);
+}
+
+pub fn fee_enabled_changed(e: &Env, enabled: bool) {
+    FeeEnabledChanged { enabled }.publish(e);
+}
+
+pub fn fee_config_set(e: &Env, token_contract: &Address, fee_dest: &Address, fee_amount: i128) {
+    FeeConfigSet {
+        token_contract: token_contract.clone(),
+        fee_dest: fee_dest.clone(),
+        fee_amount,
+    }
+    .publish(e);
+}
+
+pub fn fee_admin_set(e: &Env, amount: i128) {
+    FeeAdminSet { amount }.publish(e);
+}
+
+pub fn fee_standard_set(e: &Env, amount: i128) {
+    FeeStandardSet { amount }.publish(e);
+}
+
+pub fn fee_early_set(e: &Env, amount: i128) {
+    FeeEarlySet { amount }.publish(e);
+}
+
+pub fn fee_custom_set(e: &Env, issuer: &Address, amount: i128) {
+    FeeCustomSet {
+        issuer: issuer.clone(),
+        amount,
+    }
+    .publish(e);
+}
+
+pub fn sponsor_open_to_all_changed(e: &Env, open: bool) {
+    SponsorOpenToAllChanged { open }.publish(e);
+}
+
+pub fn sponsor_added(e: &Env, sponsor: &Address) {
+    SponsorAdded {
+        sponsor: sponsor.clone(),
+    }
+    .publish(e);
+}
+
+pub fn sponsor_removed(e: &Env, sponsor: &Address) {
+    SponsorRemoved {
+        sponsor: sponsor.clone(),
+    }
+    .publish(e);
+}
+
+pub fn vault_migrated(e: &Env, owner: &Address) {
+    VaultMigrated {
+        owner: owner.clone(),
+    }
+    .publish(e);
+}
+
+pub fn vault_index_migrated(e: &Env, owner: &Address, migrated_count: u32) {
+    VaultIndexMigrated {
+        owner: owner.clone(),
+        migrated_count,
     }
     .publish(e);
 }

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2081,3 +2081,200 @@ fn test_issue_rejects_auto_authorization_when_list_at_cap() {
         &0_i128,
     );
 }
+
+// --- Event emission tests ---
+//
+// env.events().all() returns events from the last invocation only, so each
+// test calls the entrypoint and asserts the event count immediately —
+// before any other contract call that would clear the event buffer.
+
+#[test]
+fn test_initialize_emits_contract_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(VcVaultContract, ());
+    let client = VcVaultContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_nominate_admin_emits_admin_nominated() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let nominee = Address::generate(&env);
+    client.nominate_admin(&nominee);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_accept_contract_admin_emits_admin_transferred() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let nominee = Address::generate(&env);
+    client.nominate_admin(&nominee);
+    client.accept_contract_admin();
+    // accept_contract_admin emits one event in its own invocation; the prior
+    // nominate_admin event is in a separate invocation and not in this buffer.
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_fee_enabled_emits_fee_enabled_changed() {
+    let (_env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    // setup's env mocks auths; reuse without renaming.
+    let env_ref = client.env.clone();
+    client.set_fee_enabled(&true);
+    assert_eq!(env_ref.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_fee_config_emits_fee_config_set() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let token = Address::generate(&env);
+    let dest = Address::generate(&env);
+    client.set_fee_config(&token, &dest, &1_500_000_i128);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_fee_admin_emits_fee_admin_set() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_admin(&500_i128);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_fee_standard_emits_fee_standard_set() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_standard(&2_000_000_i128);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_fee_early_emits_fee_early_set() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_early(&350_000_i128);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_fee_custom_emits_fee_custom_set() {
+    let (env, admin, issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_custom(&issuer, &100_000_i128);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_set_sponsored_vault_open_to_all_emits_event() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_sponsored_vault_open_to_all(&true);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_add_sponsored_vault_sponsor_emits_sponsor_added() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let sponsor = Address::generate(&env);
+    client.add_sponsored_vault_sponsor(&sponsor);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_remove_sponsored_vault_sponsor_emits_sponsor_removed() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let sponsor = Address::generate(&env);
+    client.add_sponsored_vault_sponsor(&sponsor);
+    client.remove_sponsored_vault_sponsor(&sponsor);
+    // The remove call is the last invocation; the add was a separate one.
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_migrate_vc_index_emits_event_with_count() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["x", "y", "z"]);
+    client.migrate_vc_index(&owner);
+    // migrate_vc_index is the last invocation; we don't care about events from
+    // create_vault (different invocation). The exact event count for this
+    // invocation is 1 (VaultIndexMigrated).
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_migrate_vc_index_noop_still_emits_event() {
+    // Even a no-op migration (vault that never had legacy data) emits the
+    // event so indexers see the migration attempt resolved.
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.migrate_vc_index(&owner);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+/// Seed a legacy `LegacyVaultVCs(owner)` entry as if produced by v0 (pre
+/// VaultVC + VaultVCIds split). Mirrors `seed_legacy_vault_vc_ids` but for
+/// the older schema consumed by `migrate(owner)`.
+fn seed_legacy_vault_vcs(
+    env: &Env,
+    contract_id: &Address,
+    owner: &Address,
+    ids: &[&str],
+    data: &str,
+    issuance_contract: &Address,
+    issuer_did: &str,
+) {
+    env.as_contract(contract_id, || {
+        let mut vec_vcs =
+            soroban_sdk::Vec::<crate::model::VerifiableCredential>::new(env);
+        for id in ids.iter() {
+            vec_vcs.push_back(crate::model::VerifiableCredential {
+                id: String::from_str(env, id),
+                data: String::from_str(env, data),
+                issuance_contract: issuance_contract.clone(),
+                issuer_did: String::from_str(env, issuer_did),
+            });
+        }
+        let key = crate::storage::DataKey::LegacyVaultVCs(owner.clone());
+        env.storage().persistent().set(&key, &vec_vcs);
+    });
+}
+
+#[test]
+fn test_migrate_emits_vault_migrated() {
+    // Simulate a v0 vault with one VC in LegacyVaultVCs and verify migrate()
+    // emits VaultMigrated. The legacy schema is reached only via the v0 →
+    // v0.1 migration path, which is what migrate() is for.
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    seed_legacy_vault_vcs(
+        &env,
+        &contract_id,
+        &owner,
+        &["legacy-vc-1"],
+        "<data>",
+        &contract_id,
+        "did:issuer",
+    );
+    client.migrate(&owner);
+    // migrate() writes via vault::store_vc which appends to the new index,
+    // but emits VaultMigrated as the only event from this entrypoint (the
+    // VC-level writes do not emit events because vault::store_vc never has).
+    assert_eq!(env.events().all().len(), 1);
+}

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2090,132 +2090,264 @@ fn test_issue_rejects_auto_authorization_when_list_at_cap() {
 
 #[test]
 fn test_initialize_emits_contract_initialized() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::ContractInitialized;
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
     let contract_id = env.register(VcVaultContract, ());
     let client = VcVaultContractClient::new(&env, &contract_id);
     client.initialize(&admin);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = ContractInitialized { admin: admin.clone() };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_nominate_admin_emits_admin_nominated() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::AdminNominated;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     let nominee = Address::generate(&env);
     client.nominate_admin(&nominee);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = AdminNominated { current_admin: admin.clone(), nominee: nominee.clone() };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_accept_contract_admin_emits_admin_transferred() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::AdminTransferred;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     let nominee = Address::generate(&env);
     client.nominate_admin(&nominee);
-    client.accept_contract_admin();
     // accept_contract_admin emits one event in its own invocation; the prior
     // nominate_admin event is in a separate invocation and not in this buffer.
-    assert_eq!(env.events().all().len(), 1);
+    client.accept_contract_admin();
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = AdminTransferred { old_admin: admin.clone(), new_admin: nominee.clone() };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_fee_enabled_emits_fee_enabled_changed() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::FeeEnabledChanged;
     let (_env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     // setup's env mocks auths; reuse without renaming.
     let env_ref = client.env.clone();
     client.set_fee_enabled(&true);
-    assert_eq!(env_ref.events().all().len(), 1);
+    let events = env_ref.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = FeeEnabledChanged { enabled: true };
+    assert_eq!(topics, expected.topics(&env_ref));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env_ref, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env_ref, &expected.data(&env_ref)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_fee_config_emits_fee_config_set() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::FeeConfigSet;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     let token = Address::generate(&env);
     let dest = Address::generate(&env);
     client.set_fee_config(&token, &dest, &1_500_000_i128);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = FeeConfigSet { token_contract: token.clone(), fee_dest: dest.clone(), fee_amount: 1_500_000_i128 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_fee_admin_emits_fee_admin_set() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::FeeAdminSet;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     client.set_fee_admin(&500_i128);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = FeeAdminSet { amount: 500_i128 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_fee_standard_emits_fee_standard_set() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::FeeStandardSet;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     client.set_fee_standard(&2_000_000_i128);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = FeeStandardSet { amount: 2_000_000_i128 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_fee_early_emits_fee_early_set() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::FeeEarlySet;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     client.set_fee_early(&350_000_i128);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = FeeEarlySet { amount: 350_000_i128 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_fee_custom_emits_fee_custom_set() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::FeeCustomSet;
     let (env, admin, issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     client.set_fee_custom(&issuer, &100_000_i128);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = FeeCustomSet { issuer: issuer.clone(), amount: 100_000_i128 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_set_sponsored_vault_open_to_all_emits_event() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::SponsorOpenToAllChanged;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     client.set_sponsored_vault_open_to_all(&true);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = SponsorOpenToAllChanged { open: true };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_add_sponsored_vault_sponsor_emits_sponsor_added() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::SponsorAdded;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     let sponsor = Address::generate(&env);
     client.add_sponsored_vault_sponsor(&sponsor);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = SponsorAdded { sponsor: sponsor.clone() };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_remove_sponsored_vault_sponsor_emits_sponsor_removed() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::SponsorRemoved;
     let (env, admin, _issuer, _contract_id, client) = setup();
     client.initialize(&admin);
     let sponsor = Address::generate(&env);
     client.add_sponsored_vault_sponsor(&sponsor);
-    client.remove_sponsored_vault_sponsor(&sponsor);
     // The remove call is the last invocation; the add was a separate one.
-    assert_eq!(env.events().all().len(), 1);
+    client.remove_sponsored_vault_sponsor(&sponsor);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = SponsorRemoved { sponsor: sponsor.clone() };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_migrate_vc_index_emits_event_with_count() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::VaultIndexMigrated;
     let (env, admin, _issuer, contract_id, client) = setup();
     client.initialize(&admin);
     let owner = Address::generate(&env);
     client.create_vault(&owner, &String::from_str(&env, "did:owner"));
     seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["x", "y", "z"]);
-    client.migrate_vc_index(&owner);
     // migrate_vc_index is the last invocation; we don't care about events from
     // create_vault (different invocation). The exact event count for this
     // invocation is 1 (VaultIndexMigrated).
-    assert_eq!(env.events().all().len(), 1);
+    client.migrate_vc_index(&owner);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = VaultIndexMigrated { owner: owner.clone(), migrated_count: 3 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 #[test]
 fn test_migrate_vc_index_noop_still_emits_event() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::VaultIndexMigrated;
     // Even a no-op migration (vault that never had legacy data) emits the
     // event so indexers see the migration attempt resolved.
     let (env, admin, _issuer, _contract_id, client) = setup();
@@ -2223,7 +2355,15 @@ fn test_migrate_vc_index_noop_still_emits_event() {
     let owner = Address::generate(&env);
     client.create_vault(&owner, &String::from_str(&env, "did:owner"));
     client.migrate_vc_index(&owner);
-    assert_eq!(env.events().all().len(), 1);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = VaultIndexMigrated { owner: owner.clone(), migrated_count: 0 };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }
 
 /// Seed a legacy `LegacyVaultVCs(owner)` entry as if produced by v0 (pre
@@ -2256,6 +2396,8 @@ fn seed_legacy_vault_vcs(
 
 #[test]
 fn test_migrate_emits_vault_migrated() {
+    use soroban_sdk::{Event as SorobanEvent, Map, Symbol, TryFromVal, Val};
+    use crate::events::VaultMigrated;
     // Simulate a v0 vault with one VC in LegacyVaultVCs and verify migrate()
     // emits VaultMigrated. The legacy schema is reached only via the v0 →
     // v0.1 migration path, which is what migrate() is for.
@@ -2272,9 +2414,17 @@ fn test_migrate_emits_vault_migrated() {
         &contract_id,
         "did:issuer",
     );
-    client.migrate(&owner);
     // migrate() writes via vault::store_vc which appends to the new index,
     // but emits VaultMigrated as the only event from this entrypoint (the
     // VC-level writes do not emit events because vault::store_vc never has).
-    assert_eq!(env.events().all().len(), 1);
+    client.migrate(&owner);
+    let events = env.events().all();
+    assert_eq!(events.len(), 1);
+    let (_, topics, data) = events.get(0).unwrap();
+    let expected = VaultMigrated { owner: owner.clone() };
+    assert_eq!(topics, expected.topics(&env));
+    assert_eq!(
+        Map::<Symbol, Val>::try_from_val(&env, &data).unwrap(),
+        Map::<Symbol, Val>::try_from_val(&env, &expected.data(&env)).unwrap(),
+    );
 }


### PR DESCRIPTION
Closes #26.

vc-vault previously emitted events for vault and VC lifecycle but every administrative mutation was silent: initialize, admin transfer (both nominate and accept), fee config, upgrade, sponsor management, and the two migration entrypoints all changed state without observable output. Indexers had to diff storage between blocks to track these, which is brittle and expensive.

This change adds 15 #[contractevent] structs covering every previously silent path:

  Admin / governance
    ContractInitialized       admin
    AdminNominated            current_admin, nominee
    AdminTransferred          old_admin, new_admin

  Upgrade
    ContractUpgraded          new_wasm_hash

  Fees
    FeeEnabledChanged         enabled
    FeeConfigSet              token_contract, fee_dest, fee_amount
    FeeAdminSet               amount
    FeeStandardSet            amount
    FeeEarlySet               amount
    FeeCustomSet              issuer, amount

  Sponsors
    SponsorOpenToAllChanged   open
    SponsorAdded              sponsor
    SponsorRemoved            sponsor

  Migrations
    VaultMigrated             owner
    VaultIndexMigrated        owner, migrated_count

Design notes:

- AdminNominated and AdminTransferred are two events for the two-step transfer so the indexer sees the full flow, not just the result. The accept path captures the outgoing admin before overwriting so the event carries both sides.
- Fee presets emit separate events per kind (admin / standard / early / custom) instead of a combined FeePresetSet { kind, amount }. Indexers can filter by exact preset without parsing an enum.
- ContractUpgraded carries only new_wasm_hash. Soroban v23 has no getter for the current WASM hash, so emitting old + new would require manually tracking the hash in instance storage — extra storage and initialize-flow complexity for data already in ledger history.
- VaultIndexMigrated reports migrated_count so an indexer can size the move without diffing state.
- Upgrade emits BEFORE update_current_contract_wasm so the event is registered against the WASM driving the upgrade, not the incoming one (which may have a different schema).

14 new tests cover every event emitter except upgrade. The upgrade entrypoint reverts when given an unresolved WASM hash, which discards the event from the same invocation; testing it requires uploading a second WASM and using its hash, out of scope here. The publisher follows the identical pattern as every other event in this file.

Tests: 121 passed (106 prior + 15 new), 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Emits explicit events for admin nomination and transfer, contract upgrades, fee configuration/enablement changes, sponsor access changes, and vault migration/index migration (includes migrated-count).
* **Tests**
  - Added unit tests covering event emissions for init, admin flows, fee/sponsor changes, and migration paths; includes legacy-vault seeding helper and a migration event test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ACTA-Team/contracts-acta/pull/37)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->