### PR TITLE
feat: O(1) map-based issuer index

### DIFF
--- a/contracts/vc-vault/src/api/mod.rs
+++ b/contracts/vc-vault/src/api/mod.rs
@@ -69,6 +69,11 @@ pub trait VcVaultTrait {
     fn get_vc_parent(e: Env, owner: Address, vc_id: String) -> Option<(Address, String)>;
     fn migrate(e: Env, owner: Address);
     fn migrate_vc_index(e: Env, owner: Address);
+    fn migrate_issuer_index(e: Env, owner: Address);
+    fn list_authorized_issuers(e: Env, owner: Address, offset: u32, limit: u32) -> Vec<Address>;
+    fn list_denied_issuers(e: Env, owner: Address, offset: u32, limit: u32) -> Vec<Address>;
+    fn authorized_issuer_count(e: Env, owner: Address) -> u32;
+    fn denied_issuer_count(e: Env, owner: Address) -> u32;
     fn create_sponsored_vault(e: Env, sponsor: Address, owner: Address, did_uri: String);
     fn set_sponsored_vault_open_to_all(e: Env, open: bool);
     fn get_sponsored_vault_open_to_all(e: Env) -> bool;

--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -159,7 +159,6 @@ impl VcVaultTrait for VcVaultContract {
         storage::write_vault_admin(&e, &owner, &owner);
         storage::write_vault_did(&e, &owner, &did_uri);
         storage::write_vault_revoked(&e, &owner, &false);
-        storage::write_vault_issuers(&e, &owner, &Vec::new(&e));
         storage::extend_vault_ttl(&e, &owner);
         events::vault_created(&e, &owner, &did_uri);
     }
@@ -614,7 +613,6 @@ impl VcVaultTrait for VcVaultContract {
         storage::write_vault_admin(&e, &owner, &owner);
         storage::write_vault_did(&e, &owner, &did_uri);
         storage::write_vault_revoked(&e, &owner, &false);
-        storage::write_vault_issuers(&e, &owner, &Vec::new(&e));
         storage::extend_vault_ttl(&e, &owner);
         storage::extend_instance_ttl(&e);
         events::sponsored_vault_created(&e, &sponsor, &owner, &did_uri);
@@ -712,6 +710,91 @@ impl VcVaultTrait for VcVaultContract {
         storage::extend_vault_ttl(&e, &owner);
         events::vault_index_migrated(&e, &owner, migrated_count);
     }
+
+    /// Migrate legacy `VaultIssuers` / `VaultDeniedIssuers` Vec entries into the
+    /// O(1) index. No auth required. Panics `IssuersAlreadyMigrated` on double-call.
+    fn migrate_issuer_index(e: Env, owner: Address) {
+        if storage::read_issuer_count(&e, &owner) > 0 {
+            panic_with_error!(e, ContractError::IssuersAlreadyMigrated);
+        }
+        let auth_count;
+        if storage::has_legacy_vault_issuers(&e, &owner) {
+            let legacy_auth = storage::read_vault_issuers(&e, &owner);
+            auth_count = legacy_auth.len();
+            for issuer in legacy_auth.iter() {
+                storage::append_issuer_to_index(&e, &owner, &issuer);
+            }
+        } else {
+            auth_count = 0;
+        }
+        let legacy_denied = storage::read_vault_denied_issuers(&e, &owner);
+        let denied_count = legacy_denied.len();
+        for issuer in legacy_denied.iter() {
+            storage::append_denied_issuer_to_index(&e, &owner, &issuer);
+        }
+        if storage::has_legacy_vault_issuers(&e, &owner) {
+            storage::remove_legacy_vault_issuers(&e, &owner);
+        }
+        if storage::has_legacy_vault_denied_issuers(&e, &owner) {
+            storage::remove_legacy_vault_denied_issuers(&e, &owner);
+        }
+        storage::extend_vault_ttl(&e, &owner);
+        events::issuer_index_migrated(&e, &owner, auth_count, denied_count);
+    }
+
+    fn list_authorized_issuers(e: Env, owner: Address, offset: u32, limit: u32) -> Vec<Address> {
+        if limit > storage::MAX_LIST_LIMIT {
+            panic_with_error!(e, ContractError::LimitTooLarge);
+        }
+        storage::extend_vault_ttl(&e, &owner);
+        let mut result = Vec::new(&e);
+        if limit == 0 {
+            return result;
+        }
+        let count = storage::read_issuer_count(&e, &owner);
+        if offset >= count {
+            return result;
+        }
+        let end = offset.saturating_add(limit).min(count);
+        for i in offset..end {
+            if let Some(addr) = storage::read_issuer_at_extend(&e, &owner, i) {
+                result.push_back(addr);
+            }
+        }
+        result
+    }
+
+    fn list_denied_issuers(e: Env, owner: Address, offset: u32, limit: u32) -> Vec<Address> {
+        if limit > storage::MAX_LIST_LIMIT {
+            panic_with_error!(e, ContractError::LimitTooLarge);
+        }
+        storage::extend_vault_ttl(&e, &owner);
+        let mut result = Vec::new(&e);
+        if limit == 0 {
+            return result;
+        }
+        let count = storage::read_denied_issuer_count(&e, &owner);
+        if offset >= count {
+            return result;
+        }
+        let end = offset.saturating_add(limit).min(count);
+        for i in offset..end {
+            if let Some(addr) = storage::read_denied_issuer_at_extend(&e, &owner, i) {
+                result.push_back(addr);
+            }
+        }
+        result
+    }
+
+    fn authorized_issuer_count(e: Env, owner: Address) -> u32 {
+        storage::extend_vault_ttl(&e, &owner);
+        storage::read_issuer_count(&e, &owner)
+    }
+
+    fn denied_issuer_count(e: Env, owner: Address) -> u32 {
+        storage::extend_vault_ttl(&e, &owner);
+        storage::read_denied_issuer_count(&e, &owner)
+    }
 }
 
 // --- Validation helpers ---
@@ -748,21 +831,19 @@ fn validate_vault_active(e: &Env, owner: &Address) {
     }
 }
 
-/// Ensure issuer is in vault's authorized list. No signature check.
+/// Ensure issuer is in vault's authorized index. No signature check.
 fn validate_issuer_authorized_only(e: &Env, owner: &Address, issuer_addr: &Address) {
     validate_vault_initialized(e, owner);
-    let issuers = storage::read_vault_issuers(e, owner);
-    if !vault::is_authorized(&issuers, issuer_addr) {
+    if !vault::is_authorized(e, owner, issuer_addr) {
         panic_with_error!(e, ContractError::IssuerNotAuthorized)
     }
 }
 
-/// Auto-authorizes issuer if not present in vault's list; panics if issuer is in the denied list.
+/// Auto-authorizes issuer if not in the authorized index; panics if in the denied index.
 fn ensure_issuer_authorized(e: &Env, owner: &Address, issuer_addr: &Address) {
     validate_vault_initialized(e, owner);
-    let issuers = storage::read_vault_issuers(e, owner);
-    if !vault::is_authorized(&issuers, issuer_addr) {
-        if storage::is_issuer_denied(e, owner, issuer_addr) {
+    if !vault::is_authorized(e, owner, issuer_addr) {
+        if storage::denied_issuer_index_contains(e, owner, issuer_addr) {
             panic_with_error!(e, ContractError::IssuerNotAuthorized)
         }
         vault::authorize_issuer(e, owner, issuer_addr);

--- a/contracts/vc-vault/src/error.rs
+++ b/contracts/vc-vault/src/error.rs
@@ -47,4 +47,6 @@ pub enum ContractError {
     InputTooLong = 19,
     /// `authorize_issuers` called with a list larger than `MAX_ISSUERS_LIST`.
     IssuerListTooLong = 20,
+    /// Issuer index already migrated; nothing to do.
+    IssuersAlreadyMigrated = 21,
 }

--- a/contracts/vc-vault/src/events/mod.rs
+++ b/contracts/vc-vault/src/events/mod.rs
@@ -349,3 +349,24 @@ pub fn vault_index_migrated(e: &Env, owner: &Address, migrated_count: u32) {
     }
     .publish(e);
 }
+
+#[contractevent]
+pub struct IssuerIndexMigrated {
+    pub owner: Address,
+    pub authorized_count: u32,
+    pub denied_count: u32,
+}
+
+pub fn issuer_index_migrated(
+    e: &Env,
+    owner: &Address,
+    authorized_count: u32,
+    denied_count: u32,
+) {
+    IssuerIndexMigrated {
+        owner: owner.clone(),
+        authorized_count,
+        denied_count,
+    }
+    .publish(e);
+}

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -77,8 +77,22 @@ pub enum DataKey {
     VaultAdmin(Address),
     VaultDid(Address),
     VaultRevoked(Address),
+    /// **Legacy.** `Vec<Address>` issuer list; read only by `migrate_issuer_index`.
     VaultIssuers(Address),
+    /// **Legacy.** `Vec<Address>` denied issuer list; read only by `migrate_issuer_index`.
     VaultDeniedIssuers(Address),
+    /// Number of authorized issuers. O(1) read.
+    VaultIssuerCount(Address),
+    /// Authorized issuer at a given position (0-indexed).
+    VaultIssuerIndex(Address, u32),
+    /// Position of a given authorized issuer. Used for O(1) existence and removal.
+    VaultIssuerPosition(Address, Address),
+    /// Number of denied issuers. O(1) read.
+    VaultDeniedIssuerCount(Address),
+    /// Denied issuer at a given position (0-indexed).
+    VaultDeniedIssuerIndex(Address, u32),
+    /// Position of a given denied issuer. Used for O(1) existence and removal.
+    VaultDeniedIssuerPosition(Address, Address),
     VaultVC(Address, String),
     /// **Legacy v0.1 index.** A monolithic `Vec<String>` of vc_ids per vault.
     /// New issuance writes to the O(1) index keys below; this entry is read
@@ -358,6 +372,257 @@ pub fn remove_denied_issuer(e: &Env, owner: &Address, issuer: &Address) {
     }
 }
 
+pub fn has_legacy_vault_issuers(e: &Env, owner: &Address) -> bool {
+    e.storage().persistent().has(&DataKey::VaultIssuers(owner.clone()))
+}
+
+pub fn remove_legacy_vault_issuers(e: &Env, owner: &Address) {
+    e.storage().persistent().remove(&DataKey::VaultIssuers(owner.clone()));
+}
+
+pub fn has_legacy_vault_denied_issuers(e: &Env, owner: &Address) -> bool {
+    e.storage().persistent().has(&DataKey::VaultDeniedIssuers(owner.clone()))
+}
+
+pub fn remove_legacy_vault_denied_issuers(e: &Env, owner: &Address) {
+    e.storage().persistent().remove(&DataKey::VaultDeniedIssuers(owner.clone()));
+}
+
+// --- Authorized issuer index ---
+
+pub fn read_issuer_count(e: &Env, owner: &Address) -> u32 {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultIssuerCount(owner.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_issuer_count(e: &Env, owner: &Address, count: u32) {
+    let key = DataKey::VaultIssuerCount(owner.clone());
+    e.storage().persistent().set(&key, &count);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn read_issuer_at(e: &Env, owner: &Address, position: u32) -> Option<Address> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultIssuerIndex(owner.clone(), position))
+}
+
+pub fn read_issuer_at_extend(e: &Env, owner: &Address, position: u32) -> Option<Address> {
+    let key = DataKey::VaultIssuerIndex(owner.clone(), position);
+    if !e.storage().persistent().has(&key) {
+        return None;
+    }
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+    e.storage().persistent().get(&key)
+}
+
+pub fn write_issuer_at(e: &Env, owner: &Address, position: u32, issuer: &Address) {
+    let key = DataKey::VaultIssuerIndex(owner.clone(), position);
+    e.storage().persistent().set(&key, issuer);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_issuer_at(e: &Env, owner: &Address, position: u32) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultIssuerIndex(owner.clone(), position));
+}
+
+pub fn read_issuer_position(e: &Env, owner: &Address, issuer: &Address) -> Option<u32> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultIssuerPosition(owner.clone(), issuer.clone()))
+}
+
+pub fn write_issuer_position(e: &Env, owner: &Address, issuer: &Address, position: u32) {
+    let key = DataKey::VaultIssuerPosition(owner.clone(), issuer.clone());
+    e.storage().persistent().set(&key, &position);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_issuer_position(e: &Env, owner: &Address, issuer: &Address) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultIssuerPosition(owner.clone(), issuer.clone()));
+}
+
+pub fn issuer_index_contains(e: &Env, owner: &Address, issuer: &Address) -> bool {
+    e.storage()
+        .persistent()
+        .has(&DataKey::VaultIssuerPosition(owner.clone(), issuer.clone()))
+}
+
+pub fn append_issuer_to_index(e: &Env, owner: &Address, issuer: &Address) {
+    let count = read_issuer_count(e, owner);
+    if count >= MAX_ISSUERS_LIST {
+        panic_with_error!(e, ContractError::IssuerListTooLong);
+    }
+    write_issuer_at(e, owner, count, issuer);
+    write_issuer_position(e, owner, issuer, count);
+    write_issuer_count(e, owner, count + 1);
+}
+
+pub fn remove_issuer_from_index(e: &Env, owner: &Address, issuer: &Address) {
+    let position = match read_issuer_position(e, owner, issuer) {
+        Some(p) => p,
+        None => return,
+    };
+    let count = read_issuer_count(e, owner);
+    if count == 0 {
+        return;
+    }
+    let last = count - 1;
+    if position != last {
+        if let Some(last_addr) = read_issuer_at(e, owner, last) {
+            write_issuer_at(e, owner, position, &last_addr);
+            write_issuer_position(e, owner, &last_addr, position);
+        }
+    }
+    remove_issuer_at(e, owner, last);
+    remove_issuer_position(e, owner, issuer);
+    write_issuer_count(e, owner, last);
+}
+
+pub fn clear_issuer_index(e: &Env, owner: &Address) {
+    let count = read_issuer_count(e, owner);
+    for i in 0..count {
+        if let Some(addr) = read_issuer_at(e, owner, i) {
+            remove_issuer_position(e, owner, &addr);
+        }
+        remove_issuer_at(e, owner, i);
+    }
+    write_issuer_count(e, owner, 0);
+}
+
+// --- Denied issuer index ---
+
+pub fn read_denied_issuer_count(e: &Env, owner: &Address) -> u32 {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultDeniedIssuerCount(owner.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_denied_issuer_count(e: &Env, owner: &Address, count: u32) {
+    let key = DataKey::VaultDeniedIssuerCount(owner.clone());
+    e.storage().persistent().set(&key, &count);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn read_denied_issuer_at(e: &Env, owner: &Address, position: u32) -> Option<Address> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultDeniedIssuerIndex(owner.clone(), position))
+}
+
+pub fn read_denied_issuer_at_extend(e: &Env, owner: &Address, position: u32) -> Option<Address> {
+    let key = DataKey::VaultDeniedIssuerIndex(owner.clone(), position);
+    if !e.storage().persistent().has(&key) {
+        return None;
+    }
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+    e.storage().persistent().get(&key)
+}
+
+pub fn write_denied_issuer_at(e: &Env, owner: &Address, position: u32, issuer: &Address) {
+    let key = DataKey::VaultDeniedIssuerIndex(owner.clone(), position);
+    e.storage().persistent().set(&key, issuer);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_denied_issuer_at(e: &Env, owner: &Address, position: u32) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultDeniedIssuerIndex(owner.clone(), position));
+}
+
+pub fn read_denied_issuer_position(e: &Env, owner: &Address, issuer: &Address) -> Option<u32> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::VaultDeniedIssuerPosition(owner.clone(), issuer.clone()))
+}
+
+pub fn write_denied_issuer_position(e: &Env, owner: &Address, issuer: &Address, position: u32) {
+    let key = DataKey::VaultDeniedIssuerPosition(owner.clone(), issuer.clone());
+    e.storage().persistent().set(&key, &position);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn remove_denied_issuer_position(e: &Env, owner: &Address, issuer: &Address) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::VaultDeniedIssuerPosition(owner.clone(), issuer.clone()));
+}
+
+pub fn denied_issuer_index_contains(e: &Env, owner: &Address, issuer: &Address) -> bool {
+    e.storage()
+        .persistent()
+        .has(&DataKey::VaultDeniedIssuerPosition(owner.clone(), issuer.clone()))
+}
+
+/// Append an issuer to the denied index. O(1). No cap enforced (mirrors add_denied_issuer).
+pub fn append_denied_issuer_to_index(e: &Env, owner: &Address, issuer: &Address) {
+    if denied_issuer_index_contains(e, owner, issuer) {
+        return;
+    }
+    let count = read_denied_issuer_count(e, owner);
+    write_denied_issuer_at(e, owner, count, issuer);
+    write_denied_issuer_position(e, owner, issuer, count);
+    write_denied_issuer_count(e, owner, count + 1);
+}
+
+/// Remove an issuer from the denied index using swap-and-pop. O(1).
+pub fn remove_denied_issuer_from_index(e: &Env, owner: &Address, issuer: &Address) {
+    let position = match read_denied_issuer_position(e, owner, issuer) {
+        Some(p) => p,
+        None => return,
+    };
+    let count = read_denied_issuer_count(e, owner);
+    if count == 0 {
+        return;
+    }
+    let last = count - 1;
+    if position != last {
+        if let Some(last_addr) = read_denied_issuer_at(e, owner, last) {
+            write_denied_issuer_at(e, owner, position, &last_addr);
+            write_denied_issuer_position(e, owner, &last_addr, position);
+        }
+    }
+    remove_denied_issuer_at(e, owner, last);
+    remove_denied_issuer_position(e, owner, issuer);
+    write_denied_issuer_count(e, owner, last);
+}
+
+/// Clear the entire denied issuer index. O(n).
+pub fn clear_denied_issuer_index(e: &Env, owner: &Address) {
+    let count = read_denied_issuer_count(e, owner);
+    for i in 0..count {
+        if let Some(addr) = read_denied_issuer_at(e, owner, i) {
+            remove_denied_issuer_position(e, owner, &addr);
+        }
+        remove_denied_issuer_at(e, owner, i);
+    }
+    write_denied_issuer_count(e, owner, 0);
+}
+
 // --- VC payloads (persistent) ---
 
 pub fn write_vault_vc(e: &Env, owner: &Address, vc_id: &String, vc: &VerifiableCredential) {
@@ -604,8 +869,8 @@ pub fn extend_vault_ttl(e: &Env, owner: &Address) {
         DataKey::VaultAdmin(owner.clone()),
         DataKey::VaultDid(owner.clone()),
         DataKey::VaultRevoked(owner.clone()),
-        DataKey::VaultIssuers(owner.clone()),
-        DataKey::VaultDeniedIssuers(owner.clone()),
+        DataKey::VaultIssuerCount(owner.clone()),
+        DataKey::VaultDeniedIssuerCount(owner.clone()),
         DataKey::VaultVCCount(owner.clone()),
     ];
     for key in keys {

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2278,3 +2278,188 @@ fn test_migrate_emits_vault_migrated() {
     // VC-level writes do not emit events because vault::store_vc never has).
     assert_eq!(env.events().all().len(), 1);
 }
+
+// --- Issuer O(1) index tests ---
+
+fn seed_legacy_vault_issuers(
+    env: &Env,
+    contract_id: &Address,
+    owner: &Address,
+    addrs: &[&Address],
+) {
+    env.as_contract(contract_id, || {
+        let mut vec_issuers = soroban_sdk::Vec::<Address>::new(env);
+        for addr in addrs.iter() {
+            vec_issuers.push_back((*addr).clone());
+        }
+        let key = crate::storage::DataKey::VaultIssuers(owner.clone());
+        env.storage().persistent().set(&key, &vec_issuers);
+    });
+}
+
+fn seed_legacy_vault_denied_issuers(
+    env: &Env,
+    contract_id: &Address,
+    owner: &Address,
+    addrs: &[&Address],
+) {
+    env.as_contract(contract_id, || {
+        let mut vec_denied = soroban_sdk::Vec::<Address>::new(env);
+        for addr in addrs.iter() {
+            vec_denied.push_back((*addr).clone());
+        }
+        let key = crate::storage::DataKey::VaultDeniedIssuers(owner.clone());
+        env.storage().persistent().set(&key, &vec_denied);
+    });
+}
+
+#[test]
+fn test_migrate_issuer_index_no_legacy() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    // No legacy issuer data — migrating is a no-op but must succeed.
+    client.migrate_issuer_index(&owner);
+    assert_eq!(client.authorized_issuer_count(&owner), 0);
+    assert_eq!(client.denied_issuer_count(&owner), 0);
+}
+
+#[test]
+fn test_migrate_issuer_index_with_issuers() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let issuer1 = Address::generate(&env);
+    let issuer2 = Address::generate(&env);
+    seed_legacy_vault_issuers(&env, &contract_id, &owner, &[&issuer1, &issuer2]);
+    client.migrate_issuer_index(&owner);
+    assert_eq!(client.authorized_issuer_count(&owner), 2);
+    let listed = client.list_authorized_issuers(&owner, &0_u32, &100_u32);
+    assert!(listed.contains(issuer1));
+    assert!(listed.contains(issuer2));
+}
+
+#[test]
+fn test_migrate_issuer_index_with_denied() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let denied1 = Address::generate(&env);
+    seed_legacy_vault_denied_issuers(&env, &contract_id, &owner, &[&denied1]);
+    client.migrate_issuer_index(&owner);
+    assert_eq!(client.denied_issuer_count(&owner), 1);
+    let listed = client.list_denied_issuers(&owner, &0_u32, &100_u32);
+    assert!(listed.contains(denied1));
+}
+
+#[test]
+#[should_panic]
+fn test_migrate_issuer_index_already_done() {
+    let (env, admin, issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    // Authorize an issuer to populate the new index.
+    client.authorize_issuer(&owner, &issuer);
+    // Second call must panic because the index already has entries.
+    client.migrate_issuer_index(&owner);
+}
+
+#[test]
+fn test_migrate_issuer_index_emits_event() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let i1 = Address::generate(&env);
+    let i2 = Address::generate(&env);
+    let d1 = Address::generate(&env);
+    seed_legacy_vault_issuers(&env, &contract_id, &owner, &[&i1, &i2]);
+    seed_legacy_vault_denied_issuers(&env, &contract_id, &owner, &[&d1]);
+    client.migrate_issuer_index(&owner);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn test_list_authorized_issuers_pagination() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let i1 = Address::generate(&env);
+    let i2 = Address::generate(&env);
+    let i3 = Address::generate(&env);
+    client.authorize_issuer(&owner, &i1);
+    client.authorize_issuer(&owner, &i2);
+    client.authorize_issuer(&owner, &i3);
+    // Full page.
+    let all = client.list_authorized_issuers(&owner, &0_u32, &100_u32);
+    assert_eq!(all.len(), 3);
+    // Paginated first two.
+    let page1 = client.list_authorized_issuers(&owner, &0_u32, &2_u32);
+    assert_eq!(page1.len(), 2);
+    // Offset past end.
+    let empty = client.list_authorized_issuers(&owner, &10_u32, &100_u32);
+    assert_eq!(empty.len(), 0);
+}
+
+#[test]
+fn test_list_denied_issuers_pagination() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    let i1 = Address::generate(&env);
+    let i2 = Address::generate(&env);
+    client.authorize_issuer(&owner, &i1);
+    client.authorize_issuer(&owner, &i2);
+    client.revoke_issuer(&owner, &i1);
+    client.revoke_issuer(&owner, &i2);
+    let all = client.list_denied_issuers(&owner, &0_u32, &100_u32);
+    assert_eq!(all.len(), 2);
+    let page1 = client.list_denied_issuers(&owner, &0_u32, &1_u32);
+    assert_eq!(page1.len(), 1);
+    let empty = client.list_denied_issuers(&owner, &5_u32, &100_u32);
+    assert_eq!(empty.len(), 0);
+}
+
+#[test]
+fn test_authorized_issuer_count() {
+    let (env, admin, issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    assert_eq!(client.authorized_issuer_count(&owner), 0);
+    client.authorize_issuer(&owner, &issuer);
+    assert_eq!(client.authorized_issuer_count(&owner), 1);
+}
+
+#[test]
+fn test_is_authorized_o1() {
+    let (env, admin, issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let listed = client.list_authorized_issuers(&owner, &0_u32, &100_u32);
+    assert!(listed.contains(issuer));
+}
+
+#[test]
+fn test_revoke_issuer_updates_index() {
+    let (env, admin, issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    assert_eq!(client.authorized_issuer_count(&owner), 1);
+    assert_eq!(client.denied_issuer_count(&owner), 0);
+    client.revoke_issuer(&owner, &issuer);
+    assert_eq!(client.authorized_issuer_count(&owner), 0);
+    assert_eq!(client.denied_issuer_count(&owner), 1);
+    let denied = client.list_denied_issuers(&owner, &0_u32, &100_u32);
+    assert!(denied.contains(issuer));
+}

--- a/contracts/vc-vault/src/vault/issuer.rs
+++ b/contracts/vc-vault/src/vault/issuer.rs
@@ -4,58 +4,34 @@ use crate::error::ContractError;
 use crate::storage;
 use soroban_sdk::{panic_with_error, Address, Env, Vec};
 
-/// Adds an issuer to the vault's authorized list; panics if already present.
-///
-/// Enforces `MAX_ISSUERS_LIST` here rather than at the entrypoint so the cap
-/// covers every growth path:
-///   - direct `authorize_issuer(owner, issuer)` calls
-///   - auto-authorization triggered by `issue` / `batch_issue` /
-///     `issue_linked` via `ensure_issuer_authorized`
-///
-/// `authorize_issuers(list)` is checked at its entrypoint instead because it
-/// fully replaces the stored list (the cap on the new list is what matters).
+pub fn is_authorized(e: &Env, owner: &Address, issuer: &Address) -> bool {
+    storage::issuer_index_contains(e, owner, issuer)
+}
+
 pub fn authorize_issuer(e: &Env, owner: &Address, issuer: &Address) {
-    let mut issuers: Vec<Address> = storage::read_vault_issuers(e, owner);
-    if is_authorized(&issuers, issuer) {
-        panic_with_error!(e, ContractError::IssuerAlreadyAuthorized)
+    if storage::issuer_index_contains(e, owner, issuer) {
+        panic_with_error!(e, ContractError::IssuerAlreadyAuthorized);
     }
-    if issuers.len() >= storage::MAX_ISSUERS_LIST {
-        panic_with_error!(e, ContractError::IssuerListTooLong)
-    }
-    issuers.push_front(issuer.clone());
-    storage::write_vault_issuers(e, owner, &issuers);
-    storage::remove_denied_issuer(e, owner, issuer);
+    storage::append_issuer_to_index(e, owner, issuer);
+    storage::remove_denied_issuer_from_index(e, owner, issuer);
 }
 
-/// Replaces the vault's full issuer list, silently dropping any duplicates.
+/// Replaces the full authorized issuer index, silently dropping duplicates.
 pub fn authorize_issuers(e: &Env, owner: &Address, issuers: &Vec<Address>) {
-    let mut deduped: Vec<Address> = Vec::new(e);
+    storage::clear_issuer_index(e, owner);
+    let mut seen: Vec<Address> = Vec::new(e);
     for issuer in issuers.iter() {
-        if !deduped.contains(issuer.clone()) {
-            deduped.push_back(issuer);
+        if !seen.contains(issuer.clone()) {
+            seen.push_back(issuer.clone());
+            storage::append_issuer_to_index(e, owner, &issuer);
         }
     }
-    storage::write_vault_issuers(e, owner, &deduped);
 }
 
-/// Removes an issuer from the vault and adds them to the deny list; panics if not present.
 pub fn revoke_issuer(e: &Env, owner: &Address, issuer: &Address) {
-    let issuers = storage::read_vault_issuers(e, owner);
-    let original_len = issuers.len();
-    let mut filtered: Vec<Address> = Vec::new(e);
-    for addr in issuers.iter() {
-        if &addr != issuer {
-            filtered.push_back(addr);
-        }
+    if !storage::issuer_index_contains(e, owner, issuer) {
+        panic_with_error!(e, ContractError::IssuerNotAuthorized);
     }
-    if filtered.len() == original_len {
-        panic_with_error!(e, ContractError::IssuerNotAuthorized)
-    }
-    storage::write_vault_issuers(e, owner, &filtered);
-    storage::add_denied_issuer(e, owner, issuer);
-}
-
-/// Returns true if the issuer is present in the authorized list.
-pub fn is_authorized(issuers: &Vec<Address>, issuer: &Address) -> bool {
-    issuers.contains(issuer.clone())
+    storage::remove_issuer_from_index(e, owner, issuer);
+    storage::append_denied_issuer_to_index(e, owner, issuer);
 }


### PR DESCRIPTION

- [x] Closes #27 

## Summary

- Replaces `VaultIssuers(Address)` and `VaultDeniedIssuers(Address)` monolithic `Vec<Address>` entries with a three-key index per side: `Count`, `Index(pos)`, `Position(issuer)` — making authorize, revoke, and existence checks O(1)
- Adds `migrate_issuer_index(owner)` to bridge legacy Vec data forward (no auth, same pattern as `migrate_vc_index`)
- Adds `list_authorized_issuers`, `list_denied_issuers`, `authorized_issuer_count`, `denied_issuer_count` entrypoints
- Updates `extend_vault_ttl` to track the new count keys instead of the old Vec keys