### PR TITLE
perf: dedupe storage reads in ensure_issuer_authorized

### DIFF
--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -846,7 +846,7 @@ fn ensure_issuer_authorized(e: &Env, owner: &Address, issuer_addr: &Address) {
         if storage::denied_issuer_index_contains(e, owner, issuer_addr) {
             panic_with_error!(e, ContractError::IssuerNotAuthorized)
         }
-        vault::authorize_issuer(e, owner, issuer_addr);
+        storage::append_issuer_to_index(e, owner, issuer_addr);
     }
 }
 

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2463,3 +2463,23 @@ fn test_revoke_issuer_updates_index() {
     let denied = client.list_denied_issuers(&owner, &0_u32, &100_u32);
     assert!(denied.contains(issuer));
 }
+
+#[test]
+fn test_auto_authorize_on_repeated_issue() {
+    // Exercises the auto-authorize path in ensure_issuer_authorized across
+    // multiple issuances: issuer must end up in the index exactly once.
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    let issuer_did = String::from_str(&env, "did:issuer");
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+
+    let vc_data = String::from_str(&env, "data");
+    for id in ["vc-0","vc-1","vc-2","vc-3","vc-4","vc-5","vc-6","vc-7","vc-8","vc-9"] {
+        let vc_id = String::from_str(&env, id);
+        client.issue(&owner, &vc_id, &vc_data, &contract_id, &issuer, &issuer_did, &0_i128);
+    }
+
+    assert_eq!(client.authorized_issuer_count(&owner), 1);
+    assert_eq!(client.vc_count(&owner), 10);
+}


### PR DESCRIPTION
- closes #28 

## Summary

- On the auto-authorize path, `is_authorized` and `denied_issuer_index_contains` already confirm the issuer is absent from both indexes before the append step
- The previous `vault::authorize_issuer` call re-checked `VaultIssuerPosition` (redundant) and called `remove_denied_issuer_from_index` which re-read `VaultDeniedIssuerPosition` as a guaranteed no-op
- Replace with a direct `storage::append_issuer_to_index` call, saving 2 persistent reads (~6-10k instructions) per `issue`, `batch_issue`, and `issue_linked` invocation with a new issuer

`vault::authorize_issuer` retains its defensive checks for the direct `authorize_issuer` entrypoint path.