### PR TITLE
feat: validate fee bounds at entrypoints

### DIFF
--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -66,6 +66,7 @@ impl VcVaultTrait for VcVaultContract {
 
     /// Configure fee: token, destination, amount. Admin only.
     fn set_fee_config(e: Env, token_contract: Address, fee_dest: Address, fee_amount: i128) {
+        require_fee_amount(&e, fee_amount);
         validate_contract_admin(&e);
         storage::write_fee_token_contract(&e, &token_contract);
         storage::write_fee_dest(&e, &fee_dest);
@@ -83,6 +84,7 @@ impl VcVaultTrait for VcVaultContract {
     }
 
     fn set_fee_admin(e: Env, fee_amount: i128) {
+        require_fee_amount(&e, fee_amount);
         validate_contract_admin(&e);
         storage::write_fee_admin(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
@@ -90,6 +92,7 @@ impl VcVaultTrait for VcVaultContract {
     }
 
     fn set_fee_standard(e: Env, fee_amount: i128) {
+        require_fee_amount(&e, fee_amount);
         validate_contract_admin(&e);
         storage::write_fee_standard(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
@@ -97,6 +100,7 @@ impl VcVaultTrait for VcVaultContract {
     }
 
     fn set_fee_early(e: Env, fee_amount: i128) {
+        require_fee_amount(&e, fee_amount);
         validate_contract_admin(&e);
         storage::write_fee_early(&e, &fee_amount);
         storage::extend_instance_ttl(&e);
@@ -104,6 +108,7 @@ impl VcVaultTrait for VcVaultContract {
     }
 
     fn set_fee_custom(e: Env, issuer: Address, fee_amount: i128) {
+        require_fee_amount(&e, fee_amount);
         validate_contract_admin(&e);
         storage::write_fee_custom(&e, &issuer, &fee_amount);
         storage::extend_instance_ttl(&e);
@@ -364,6 +369,7 @@ impl VcVaultTrait for VcVaultContract {
         require_vc_id_len(&e, &vc_id);
         require_vc_data_len(&e, &vc_data);
         require_issuer_did_len(&e, &issuer_did);
+        require_fee_amount(&e, fee_override);
         issuer_addr.require_auth();
         let this = e.current_contract_address();
         if vault_contract != this {
@@ -424,6 +430,7 @@ impl VcVaultTrait for VcVaultContract {
         vcs: Vec<(String, String)>,
     ) -> Vec<String> {
         require_issuer_did_len(&e, &issuer_did);
+        require_fee_amount(&e, fee_override);
         // Validate every (vc_id, vc_data) pair up front so an oversize entry
         // late in the batch doesn't waste CPU on the earlier valid ones.
         for entry in vcs.iter() {
@@ -915,5 +922,14 @@ fn require_date_len(e: &Env, date: &String) {
 fn require_issuers_list_len(e: &Env, issuers: &Vec<Address>) {
     if issuers.len() > storage::MAX_ISSUERS_LIST {
         panic_with_error!(e, ContractError::IssuerListTooLong);
+    }
+}
+
+fn require_fee_amount(e: &Env, amount: i128) {
+    if amount < 0 {
+        panic_with_error!(e, ContractError::InvalidFeeAmount);
+    }
+    if amount > storage::MAX_FEE_AMOUNT {
+        panic_with_error!(e, ContractError::FeeOutOfBounds);
     }
 }

--- a/contracts/vc-vault/src/error.rs
+++ b/contracts/vc-vault/src/error.rs
@@ -49,4 +49,8 @@ pub enum ContractError {
     IssuerListTooLong = 20,
     /// Issuer index already migrated; nothing to do.
     IssuersAlreadyMigrated = 21,
+    /// Fee amount is negative.
+    InvalidFeeAmount = 22,
+    /// Fee amount exceeds `MAX_FEE_AMOUNT`.
+    FeeOutOfBounds = 23,
 }

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -59,6 +59,8 @@ pub const MAX_ISSUER_DID_LEN: u32 = 256;
 pub const MAX_DATE_LEN: u32 = 64;
 /// Maximum number of addresses accepted by `authorize_issuers(list)`.
 pub const MAX_ISSUERS_LIST: u32 = 100;
+/// Maximum accepted fee amount in stroops (10^18).
+pub const MAX_FEE_AMOUNT: i128 = 1_000_000_000_000_000_000;
 
 /// Storage keys. Instance = admin, fees, flags. Persistent = vault metadata, VCs, status.
 #[derive(Clone)]

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2483,3 +2483,141 @@ fn test_auto_authorize_on_repeated_issue() {
     assert_eq!(client.authorized_issuer_count(&owner), 1);
     assert_eq!(client.vc_count(&owner), 10);
 }
+
+// --- Fee bounds validation tests ---
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_set_fee_config_rejects_negative_amount() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let token = Address::generate(&env);
+    let dest = Address::generate(&env);
+    client.set_fee_config(&token, &dest, &-1_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #23)")]
+fn test_set_fee_config_rejects_amount_over_max() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let token = Address::generate(&env);
+    let dest = Address::generate(&env);
+    client.set_fee_config(&token, &dest, &1_000_000_000_000_000_001_i128);
+}
+
+#[test]
+fn test_set_fee_config_accepts_zero() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let token = Address::generate(&env);
+    let dest = Address::generate(&env);
+    client.set_fee_config(&token, &dest, &0_i128);
+    assert_eq!(client.fee_config().fee_amount, Some(0));
+}
+
+#[test]
+fn test_set_fee_config_accepts_max() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let token = Address::generate(&env);
+    let dest = Address::generate(&env);
+    client.set_fee_config(&token, &dest, &1_000_000_000_000_000_000_i128);
+    assert_eq!(client.fee_config().fee_amount, Some(1_000_000_000_000_000_000));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_set_fee_admin_rejects_negative() {
+    let (_env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_admin(&-1_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_set_fee_standard_rejects_negative() {
+    let (_env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_standard(&-1_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_set_fee_early_rejects_negative() {
+    let (_env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    client.set_fee_early(&-1_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_set_fee_custom_rejects_negative() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let issuer = Address::generate(&env);
+    client.set_fee_custom(&issuer, &-1_i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_issue_rejects_negative_fee_override() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-1"),
+        &String::from_str(&env, "data"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &-1_i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #23)")]
+fn test_issue_rejects_fee_override_over_max() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    client.issue(
+        &owner,
+        &String::from_str(&env, "vc-1"),
+        &String::from_str(&env, "data"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &1_000_000_000_000_000_001_i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_batch_issue_rejects_negative_fee_override() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+    let vcs = vec![
+        &env,
+        (
+            String::from_str(&env, "vc-1"),
+            String::from_str(&env, "data"),
+        ),
+    ];
+    client.batch_issue(
+        &issuer,
+        &owner,
+        &contract_id,
+        &String::from_str(&env, "did:issuer"),
+        &-1_i128,
+        &vcs,
+    );
+}


### PR DESCRIPTION
- [x] Closes #29 

## Summary

- Adds `InvalidFeeAmount = 22` (negative) and `FeeOutOfBounds = 23` (exceeds 10^18) error codes
- Adds `MAX_FEE_AMOUNT: i128 = 1_000_000_000_000_000_000` constant in `storage/mod.rs`
- Adds `require_fee_amount` helper (mirrors existing `require_*` pattern) called as first validation in `set_fee_config`, `set_fee_admin`, `set_fee_standard`, `set_fee_early`, `set_fee_custom`, `issue`, and `batch_issue`