### PR TITLE
feat: remove MAX_VCS_PER_VAULT cap + chunked migrate_vc_index

### DIFF
--- a/contracts/vc-vault/README.md
+++ b/contracts/vc-vault/README.md
@@ -77,6 +77,11 @@ Linked VCs establish a parent–child relationship between credentials across va
 | Function | Auth | Description |
 |---|---|---|
 | `migrate(owner)` | vault admin | Migrate VCs from the legacy storage format to the current format. Fails with `VCSAlreadyMigrated` if migration has already been run. |
+| `migrate_vc_index(owner)` | none | Migrate the v0.1 `Vec<String>` VC index to the O(1) index. Safe for vaults with ≤ 10 legacy entries. |
+| `migrate_vc_index_chunk(owner, chunk_size)` | none | Chunked variant for large legacy vaults. Migrates up to `chunk_size` entries (max 10) per call. Returns remaining count; 0 means done. Call repeatedly until 0. |
+| `migrate_issuer_index(owner)` | none | Migrate legacy `Vec<Address>` issuer lists to the O(1) index. |
+
+Vaults have no per-vault VC cap; the limit is the u32 position counter (~4.3 billion) and storage rent paid by transactors.
 
 ---
 
@@ -112,6 +117,15 @@ Authorization is enforced via `require_auth()` on every privileged operation. Re
 | 12 | `VCAlreadyExists` | `issue` or `push` would create a duplicate VC ID in the target vault |
 | 13 | `NoPendingAdmin` | `accept_contract_admin` called with no active nomination |
 | 14 | `ParentVCInvalid` | `issue_linked` called with a parent VC that does not exist or is revoked |
+| 15 | `VaultFull` | u32 VC position counter would overflow (~4.3 billion VCs) |
+| 16 | `LimitTooLarge` | `list_vc_ids` / `list_authorized_issuers` `limit` exceeds `MAX_LIST_LIMIT` (200) |
+| 17 | `BatchTooLarge` | `batch_issue` request exceeds `MAX_BATCH_SIZE` (5) |
+| 18 | `BatchEmpty` | `batch_issue` called with an empty VC list |
+| 19 | `InputTooLong` | A string field exceeds its per-field length cap |
+| 20 | `IssuerListTooLong` | `authorize_issuers` called with a list exceeding `MAX_ISSUERS_LIST` (100) |
+| 21 | `IssuersAlreadyMigrated` | `migrate_issuer_index` called after migration is complete |
+| 22 | `InvalidFeeAmount` | Fee amount is negative |
+| 23 | `FeeOutOfBounds` | Fee amount exceeds `MAX_FEE_AMOUNT` (10^18 stroops) |
 
 ---
 

--- a/contracts/vc-vault/src/api/mod.rs
+++ b/contracts/vc-vault/src/api/mod.rs
@@ -69,6 +69,7 @@ pub trait VcVaultTrait {
     fn get_vc_parent(e: Env, owner: Address, vc_id: String) -> Option<(Address, String)>;
     fn migrate(e: Env, owner: Address);
     fn migrate_vc_index(e: Env, owner: Address);
+    fn migrate_vc_index_chunk(e: Env, owner: Address, chunk_size: u32) -> u32;
     fn migrate_issuer_index(e: Env, owner: Address);
     fn list_authorized_issuers(e: Env, owner: Address, offset: u32, limit: u32) -> Vec<Address>;
     fn list_denied_issuers(e: Env, owner: Address, offset: u32, limit: u32) -> Vec<Address>;

--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -718,6 +718,50 @@ impl VcVaultTrait for VcVaultContract {
         events::vault_index_migrated(&e, &owner, migrated_count);
     }
 
+    /// Chunked variant of `migrate_vc_index` for large legacy vaults.
+    /// Migrates up to `chunk_size` entries per call (clamped to [1, MAX_MIGRATION_BATCH]).
+    /// Returns the number of entries still remaining; 0 means migration is complete.
+    /// No auth required. Panics `VCSAlreadyMigrated` on double-call after completion.
+    fn migrate_vc_index_chunk(e: Env, owner: Address, chunk_size: u32) -> u32 {
+        let chunk_size = chunk_size
+            .max(1)
+            .min(storage::MAX_MIGRATION_BATCH);
+
+        let legacy_ids = storage::read_legacy_vault_vc_ids(&e, &owner);
+        let cursor = storage::read_migration_cursor(&e, &owner);
+        let total = legacy_ids.len();
+
+        if total == 0 && cursor == 0 {
+            if storage::read_vc_count(&e, &owner) > 0 {
+                panic_with_error!(e, ContractError::VCSAlreadyMigrated);
+            }
+            storage::extend_vault_ttl(&e, &owner);
+            events::vault_index_migrated(&e, &owner, 0);
+            return 0;
+        }
+
+        let end = (cursor + chunk_size).min(total);
+        for i in cursor..end {
+            if let Some(vc_id) = legacy_ids.get(i) {
+                storage::append_vc_to_index(&e, &owner, &vc_id);
+            }
+        }
+
+        if end >= total {
+            storage::remove_legacy_vault_vc_ids(&e, &owner);
+            if storage::has_migration_cursor(&e, &owner) {
+                storage::remove_migration_cursor(&e, &owner);
+            }
+            storage::extend_vault_ttl(&e, &owner);
+            events::vault_index_migrated(&e, &owner, total);
+            0
+        } else {
+            storage::write_migration_cursor(&e, &owner, end);
+            storage::extend_vault_ttl(&e, &owner);
+            total - end
+        }
+    }
+
     /// Migrate legacy `VaultIssuers` / `VaultDeniedIssuers` Vec entries into the
     /// O(1) index. No auth required. Panics `IssuersAlreadyMigrated` on double-call.
     fn migrate_issuer_index(e: Env, owner: Address) {

--- a/contracts/vc-vault/src/contract.rs
+++ b/contracts/vc-vault/src/contract.rs
@@ -740,7 +740,7 @@ impl VcVaultTrait for VcVaultContract {
             return 0;
         }
 
-        let end = (cursor + chunk_size).min(total);
+        let end = cursor.saturating_add(chunk_size).min(total);
         for i in cursor..end {
             if let Some(vc_id) = legacy_ids.get(i) {
                 storage::append_vc_to_index(&e, &owner, &vc_id);

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -10,9 +10,8 @@ const INSTANCE_TTL_EXTEND_TO: u32 = 3_110_400;
 const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
 const PERSISTENT_TTL_EXTEND_TO: u32 = 3_110_400;
 
-/// Maximum number of active VCs that may be tracked in a single vault. Hitting
-/// this cap prevents new issuance until VCs are revoked or pushed away.
-pub const MAX_VCS_PER_VAULT: u32 = 1_000;
+/// Maximum entries migrated per `migrate_vc_index_chunk` call.
+pub const MAX_MIGRATION_BATCH: u32 = 10;
 
 /// Maximum number of vc_ids that may be returned by a single `list_vc_ids`
 /// call. Each slot read costs ~3-5k instructions in Soroban; capping at 200
@@ -100,6 +99,8 @@ pub enum DataKey {
     /// New issuance writes to the O(1) index keys below; this entry is read
     /// only by `migrate_vc_index(owner)` to bridge data forward.
     VaultVCIds(Address),
+    /// Cursor for chunked migration; absent when migration is not in progress.
+    LegacyMigrationCursor(Address),
     /// Number of active VCs in this vault. O(1) read.
     VaultVCCount(Address),
     /// vc_id at a given position (0-indexed). Used to enumerate the index.
@@ -727,17 +728,17 @@ pub fn vc_index_contains(e: &Env, owner: &Address, vc_id: &String) -> bool {
         .has(&DataKey::VaultVCPosition(owner.clone(), vc_id.clone()))
 }
 
-/// Append vc_id to the index. O(1). Panics with `VaultFull` if the cap is hit.
+/// Append vc_id to the index. O(1). Panics with `VaultFull` on u32 overflow.
 /// Caller must guarantee vc_id is not already indexed (issuance/push paths
 /// already check `read_vault_vc(...).is_some()`).
 pub fn append_vc_to_index(e: &Env, owner: &Address, vc_id: &String) {
     let count = read_vc_count(e, owner);
-    if count >= MAX_VCS_PER_VAULT {
-        panic_with_error!(e, ContractError::VaultFull);
-    }
+    let next = count
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::VaultFull));
     write_vc_id_at(e, owner, count, vc_id);
     write_vc_position(e, owner, vc_id, count);
-    write_vc_count(e, owner, count + 1);
+    write_vc_count(e, owner, next);
 }
 
 /// Remove vc_id from the index using swap-and-pop. O(1). No-op when vc_id is
@@ -789,6 +790,35 @@ pub fn remove_legacy_vault_vc_ids(e: &Env, owner: &Address) {
     e.storage()
         .persistent()
         .remove(&DataKey::VaultVCIds(owner.clone()));
+}
+
+// --- Chunked migration cursor ---
+
+pub fn read_migration_cursor(e: &Env, owner: &Address) -> u32 {
+    e.storage()
+        .persistent()
+        .get(&DataKey::LegacyMigrationCursor(owner.clone()))
+        .unwrap_or(0)
+}
+
+pub fn write_migration_cursor(e: &Env, owner: &Address, cursor: u32) {
+    let key = DataKey::LegacyMigrationCursor(owner.clone());
+    e.storage().persistent().set(&key, &cursor);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+}
+
+pub fn has_migration_cursor(e: &Env, owner: &Address) -> bool {
+    e.storage()
+        .persistent()
+        .has(&DataKey::LegacyMigrationCursor(owner.clone()))
+}
+
+pub fn remove_migration_cursor(e: &Env, owner: &Address) {
+    e.storage()
+        .persistent()
+        .remove(&DataKey::LegacyMigrationCursor(owner.clone()));
 }
 
 // --- VC parent links (persistent) ---

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2621,3 +2621,93 @@ fn test_batch_issue_rejects_negative_fee_override() {
         &vcs,
     );
 }
+
+// --- migrate_vc_index_chunk tests ---
+
+#[test]
+fn test_migrate_vc_index_chunk_partial_then_complete() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+
+    seed_legacy_vault_vc_ids(
+        &env,
+        &contract_id,
+        &owner,
+        &[
+            "vc-0", "vc-1", "vc-2", "vc-3", "vc-4",
+            "vc-5", "vc-6", "vc-7", "vc-8", "vc-9",
+            "vc-10", "vc-11", "vc-12", "vc-13", "vc-14",
+        ],
+    );
+
+    // First chunk: migrates 10, returns 5 remaining.
+    let remaining = client.migrate_vc_index_chunk(&owner, &10_u32);
+    assert_eq!(remaining, 5);
+    assert_eq!(client.vc_count(&owner), 10);
+
+    // Second chunk: completes migration, returns 0.
+    let remaining = client.migrate_vc_index_chunk(&owner, &10_u32);
+    assert_eq!(remaining, 0);
+    assert_eq!(client.vc_count(&owner), 15);
+
+    let listed = client.list_vc_ids(&owner, &0_u32, &200_u32);
+    assert_eq!(listed.len(), 15);
+    assert!(listed.contains(String::from_str(&env, "vc-0")));
+    assert!(listed.contains(String::from_str(&env, "vc-7")));
+    assert!(listed.contains(String::from_str(&env, "vc-14")));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")] // VCSAlreadyMigrated
+fn test_migrate_vc_index_chunk_already_migrated() {
+    let (env, admin, _issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    seed_legacy_vault_vc_ids(&env, &contract_id, &owner, &["vc-1"]);
+
+    client.migrate_vc_index(&owner);
+    // Now vc_count > 0 and no legacy entry; chunk call must panic.
+    client.migrate_vc_index_chunk(&owner, &10_u32);
+}
+
+#[test]
+fn test_migrate_vc_index_chunk_fresh_vault_noop() {
+    let (env, admin, _issuer, _contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+
+    let remaining = client.migrate_vc_index_chunk(&owner, &10_u32);
+    assert_eq!(remaining, 0);
+    assert_eq!(client.vc_count(&owner), 0);
+}
+
+#[test]
+fn test_vault_full_at_u32_max() {
+    let (env, admin, issuer, contract_id, client) = setup();
+    client.initialize(&admin);
+    let owner = Address::generate(&env);
+    client.create_vault(&owner, &String::from_str(&env, "did:owner"));
+    client.authorize_issuer(&owner, &issuer);
+
+    // Seed VaultVCCount = u32::MAX directly to simulate overflow boundary.
+    env.as_contract(&contract_id, || {
+        let key = crate::storage::DataKey::VaultVCCount(owner.clone());
+        env.storage().persistent().set(&key, &u32::MAX);
+    });
+
+    // issue must panic with VaultFull (#15) because checked_add overflows.
+    let result = client.try_issue(
+        &owner,
+        &String::from_str(&env, "overflow-vc"),
+        &String::from_str(&env, "data"),
+        &contract_id,
+        &issuer,
+        &String::from_str(&env, "did:issuer"),
+        &0_i128,
+    );
+    assert!(result.is_err());
+}

--- a/contracts/vc-vault/src/test.rs
+++ b/contracts/vc-vault/src/test.rs
@@ -2686,6 +2686,7 @@ fn test_migrate_vc_index_chunk_fresh_vault_noop() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #15)")] // VaultFull
 fn test_vault_full_at_u32_max() {
     let (env, admin, issuer, contract_id, client) = setup();
     client.initialize(&admin);
@@ -2699,8 +2700,7 @@ fn test_vault_full_at_u32_max() {
         env.storage().persistent().set(&key, &u32::MAX);
     });
 
-    // issue must panic with VaultFull (#15) because checked_add overflows.
-    let result = client.try_issue(
+    client.issue(
         &owner,
         &String::from_str(&env, "overflow-vc"),
         &String::from_str(&env, "data"),
@@ -2709,5 +2709,4 @@ fn test_vault_full_at_u32_max() {
         &String::from_str(&env, "did:issuer"),
         &0_i128,
     );
-    assert!(result.is_err());
 }


### PR DESCRIPTION

- [x] Closes #35 

## Summary

- Removes the arbitrary `MAX_VCS_PER_VAULT = 1_000` constant; vaults are now bounded only by the u32 position counter (~4.3B) and storage rent
- Replaces the cap check in `append_vc_to_index` with a `checked_add` overflow guard (panics `VaultFull` only at u32::MAX)
- Adds `migrate_vc_index_chunk(owner, chunk_size) -> u32` for large legacy vaults that cannot be migrated in one transaction (Soroban ~25 ledger-write limit caps safe batch at ≤10 entries)
- Adds `LegacyMigrationCursor(Address)` DataKey + cursor helpers to persist position between chunk calls
- Updates README: migration table, no-cap note, full error codes table (15–23)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added chunked migration functionality for legacy VC indexes, enabling large vaults to migrate data in smaller batches across multiple transactions
  * Removed per-vault VC capacity limit; vaults now support storage up to u32 maximum entries
* **Bug Fixes & Improvements**
  * Enhanced error reporting with 9 new error codes for better vault operation visibility, including vault capacity overflow, batch size validation, and input length errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ACTA-Team/contracts-acta/pull/41)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->