### PR TITLE
chore: release vc-vault v0.3.0 to testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [`contracts/vc-vault/README.md`](contracts/vc-vault/README.md) for the full 
 | Contract | Contract ID |
 |---|---|
 | `did-stellar-registry` | `CB7ATU7SF5QUKJMSULJDJVWJZVDXC23HTZX6NFUDTSFPVT6MA575NNZJ` |
-| `vc-vault` | `CC3SQ7UTAQQDQF6PUQMQIGK3BMPB22OKMHE5Y5XELEX3JFAKC72SQOAM` |
+| `vc-vault` | `CATL4IDH7XXPDC2UHSEX2GP45PPBVDFSKUDTKCSQICDOJVDLYNKISXFH` |
 
 Network: Stellar Testnet (`Test SDF Network ; September 2015`)  
 Full deployment record: [`docs/deployments/testnet.md`](docs/deployments/testnet.md)

--- a/contracts/vc-vault/Cargo.toml
+++ b/contracts/vc-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vc-vault-contract"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }

--- a/docs/deployments/testnet.md
+++ b/docs/deployments/testnet.md
@@ -17,3 +17,4 @@ RPC: `https://soroban-testnet.stellar.org:443`
 |---|---|---|---|
 | 0.1.0 | `CC3SQ7UTAQQDQF6PUQMQIGK3BMPB22OKMHE5Y5XELEX3JFAKC72SQOAM` | 2026-05-06 | Tranche 1 initial deploy |
 | 0.2.0 | `CBXC6LXBY5FGEG46VZ4AJ2AH2EJBINBA7BMILIEO4EJYI6ZTY7K7J5D5` | 2026-05-07 | SOW D2: O(1) index + pagination + migrate + batch_issue. WASM hash `c8da61dd3dd46b2810a743d50a388c09a00f0b7e8e2df7ceb5a71c8ce5dc4dd8`. |
+| 0.3.0 | `CATL4IDH7XXPDC2UHSEX2GP45PPBVDFSKUDTKCSQICDOJVDLYNKISXFH` | 2026-05-14 | Refactoring: constructor, types rename, push_vc extraction, input caps, event emissions, O(1) issuer storage, tombstone TTL fix. WASM hash `775a141520de56fb4b1ebeb55d63e49fadf03f467ea8444cddb2caed2756ca8c`. |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,7 +39,8 @@ fi
 case "$PACKAGE" in
     vc-vault)
         WASM="target/wasm32v1-none/release/vc_vault_contract.optimized.wasm"
-        CONSTRUCTOR_ARGS=""
+        ADMIN=${VC_ADMIN:-$(stellar keys address "$SOURCE")}
+        CONSTRUCTOR_ARGS="-- --contract_admin $ADMIN"
         ;;
     did-stellar-registry)
         WASM="target/wasm32v1-none/release/did_stellar_registry.optimized.wasm"


### PR DESCRIPTION
## Summary

- Bumps `vc-vault` version to `0.3.0` in `Cargo.toml`
- Deploys to testnet: `CATL4IDH7XXPDC2UHSEX2GP45PPBVDFSKUDTKCSQICDOJVDLYNKISXFH`
- Records deployment in `docs/deployments/testnet.md`
- Updates contract ID in root `README.md`
- Fixes `scripts/deploy.sh` to pass `--contract_admin` constructor arg for `vc-vault`

## Changes since v0.2.0

- #25 cap input lengths to prevent DoS
- #26 emit events on remaining state transitions
- #27 O(1) map-based issuer storage
- #28 dedupe storage reads in ensure_issuer_authorized
- #29 validate fee bounds
- #35 remove MAX_VCS_PER_VAULT cap + paginate migrate_vc_index
- #42 remove legacy migration scaffolding
- #44 architecture cleanup (constants, validator, storage split, VcVaultDataKey)
- #46 post-architecture cleanup (constructor, types rename, push_vc extraction)
- fix: extend tombstone TTL in push_vc to prevent vc_id reuse after expiry

Closes #48