### PR TITLE
docs: update release link to v0.3.0 and add missing vault functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Soroban smart contracts for the ACTA identity and Verifiable Credential infrastructure on Stellar.
 
-**Release:** [v0.1.0](https://github.com/ACTA-Team/contracts-acta/releases/tag/v0.1.0) — Tranche 1
+**Latest release:** [vc-vault v0.3.0](https://github.com/ACTA-Team/contracts-acta/releases/tag/vc-vault-v0.3.0)
 
 ---
 
@@ -31,7 +31,7 @@ Per-holder vault for Verifiable Credentials on Stellar. Manages VC storage, issu
 | Category | Functions |
 |---|---|
 | Admin | `nominate_admin`, `accept_contract_admin`, `upgrade`, `version`, `fee_*` |
-| Vault | `create_vault`, `create_sponsored_vault`, `set_vault_admin`, `authorize_issuer`, `authorize_issuers`, `revoke_issuer`, `revoke_vault`, `list_authorized_issuers`, `list_denied_issuers` |
+| Vault | `create_vault`, `create_sponsored_vault`, `set_vault_admin`, `authorize_issuer`, `authorize_issuers`, `revoke_issuer`, `revoke_vault`, `list_authorized_issuers`, `list_denied_issuers`, `authorized_issuer_count`, `denied_issuer_count` |
 | Credentials | `issue`, `batch_issue`, `issue_linked`, `revoke`, `verify_vc`, `get_vc`, `list_vc_ids`, `vc_count`, `push` |
 
 See [`contracts/vc-vault/README.md`](contracts/vc-vault/README.md) for the full ABI, authorization model, and error codes.


### PR DESCRIPTION
- Updates release badge to point to `vc-vault-v0.3.0`
- Adds `authorized_issuer_count` and `denied_issuer_count` to the Vault functions row (were missing from the summary table)