### PR TITLE
chore: silence false-positive dead_code warnings

### DIFF
--- a/contracts/vc-vault-factory/src/lib.rs
+++ b/contracts/vc-vault-factory/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+#![allow(dead_code)]
+
 mod contract;
 mod events;
 mod storage;


### PR DESCRIPTION
## Summary

The `vc-vault-factory` crate emitted **16 `never used` warnings** on the native build. All are **false positives**: the Soroban contract macros (`#[contract]`, `#[contractclient]`, `#[contractimpl]`) generate the entrypoints (`deploy` / `deploy_sponsored` / `is_vault`), so the native dead-code linter can't see that the helper / storage / event functions are reachable through them.

Every flagged item has a real call site, and the **WASM build (the real target) reports 0 warnings**.

## Change

Add crate-level `#![allow(dead_code)]` to `contracts/vc-vault-factory/src/lib.rs`, matching the pattern already used in `vc-vault`'s `lib.rs`.

## Evidence (0 dead code)

| Item | defined | called |
|---|---|---|
| `derive_salt` | contract.rs:35 | contract.rs:52 |
| `deploy_vault` | contract.rs:50 | contract.rs:67, :75 |
| `extend_instance` | storage.rs:24 | contract.rs:66, :74, :81 |
| `get_vault_init_meta` | storage.rs:36 | contract.rs:51 |
| `set_deployed` | storage.rs:43 | contract.rs:58 |
| `is_deployed` | storage.rs:53 | contract.rs:82 |
| `vault_deployed` / `sponsored_vault_deployed` | events.rs:16, :24 | contract.rs:68, :76 |