### PR TITLE
docs: credential status convention + W3C DID resolution

### DIFF
--- a/docs/did-spec/did-stellar-v0.1.md
+++ b/docs/did-spec/did-stellar-v0.1.md
@@ -735,6 +735,73 @@ A typical issuer setup for Verifiable Credential issuance:
 
 The controller account keypair and the assertion keypair SHOULD be stored separately; the controller key authorizes on-chain mutations while the assertion key signs Verifiable Credentials.
 
+### B.4 Credential Status (Revocation)
+
+The `vc-vault` contract maintains an authoritative, real-time status for every
+stored credential via `verify_vc(vc_id) -> Valid | Revoked | Invalid`. To make
+this status **discoverable** by third-party verifiers — as required by
+[W3C VC Data Model 2.0 §4.10 (Status)](https://www.w3.org/TR/vc-data-model-2.0/#status) —
+an issuer SHOULD include a `credentialStatus` property in each issued VC using
+the status type defined here. Without it, the on-chain status registry is not
+discoverable: a verifier has no standard way to know which contract to query.
+
+W3C §4.10 leaves the status scheme out of scope and explicitly permits
+implementer-defined status methods. `StellarStatusRegistryEntry` is such a method.
+
+#### B.4.1 Status entry
+
+```json
+"credentialStatus": {
+  "type": "StellarStatusRegistryEntry",
+  "statusPurpose": "revocation",
+  "network": "testnet",
+  "statusContract": "CB...VAULT",
+  "vcId": "vc-123"
+}
+```
+
+| Property | Requirement | Meaning |
+|---|---|---|
+| `type` | MUST | Fixed `"StellarStatusRegistryEntry"`. (Per §4.10, `type` is REQUIRED.) |
+| `id` | MAY | If present, MUST be a single URL (§4.4). Optional human/resolver endpoint. |
+| `statusPurpose` | SHOULD | `"revocation"`. The vault models revocation only (no suspension). |
+| `network` | MUST | Stellar network of the vault: `mainnet` or `testnet`. |
+| `statusContract` | MUST | The `vc-vault` contract address. MUST equal the on-chain `VerifiableCredential.issuance_contract`. |
+| `vcId` | MUST | The `vc_id` to look up. |
+
+#### B.4.2 Verification algorithm
+
+For each `credentialStatus` entry whose `type` is `StellarStatusRegistryEntry`:
+
+1. Read `network`, `statusContract`, `vcId`.
+2. Invoke `verify_vc(vcId)` on `statusContract` via Stellar RPC (`simulateTransaction`,
+   read-only) on `network`.
+3. Map the returned `VCStatus`:
+   - `Valid` → credential is **active** (not revoked).
+   - `Revoked(date)` → credential was **revoked** as of `date`. The verifier MUST reject.
+   - `Invalid` → no such credential in this vault. The verifier MUST reject (unknown/invalid).
+4. The verifier SHOULD also confirm `statusContract` equals the credential's
+   on-chain `issuance_contract` to bind the status pointer to the stored record.
+
+On-chain status is the authoritative source and reflects `revoke()` /
+`push` / `receive_push` effects in real time, with no caching window.
+
+#### B.4.3 Privacy
+
+Reading status is a read-only RPC call against public ledger state; the issuer is
+**NOT** notified when a verifier checks status. This satisfies the normative
+§4.10 privacy requirement that status mechanisms MUST NOT enable tracking of
+holders or subjects ("phoning home") — a structural advantage over hosted
+status-list endpoints.
+
+#### B.4.4 Notes
+
+- On-chain `Valid` reflects **revocation state only**. It does NOT evaluate
+  `validFrom` / `validUntil`; temporal validity remains the verifier's
+  responsibility per the VC Data Model.
+- Verifiers that do not understand `StellarStatusRegistryEntry` fall back to their
+  own status-evaluation logic (status processing is non-normative in §4.10).
+
 ## 11. References
 
 - [W3C Decentralized Identifiers (DIDs) v1.1](https://www.w3.org/TR/did-1.1/)

--- a/docs/did-spec/did-stellar-v0.1.md
+++ b/docs/did-spec/did-stellar-v0.1.md
@@ -368,6 +368,60 @@ In v0.1, all keys are Ed25519 expressed with the Multikey prefix `z6Mk...` (vari
 | `type` | Value from `DidService.service_type` |
 | `serviceEndpoint` | Value from `DidService.service_endpoint` |
 
+### 5.7 DID Resolution
+
+A conformant resolver implements `resolve(did, resolutionOptions)` and returns the
+three-component DID Resolution Result defined by
+[W3C DID Resolution v0.3](https://www.w3.org/TR/did-resolution/):
+`didResolutionMetadata`, `didDocument`, and `didDocumentMetadata`. Resolution is an
+**off-chain** operation that reads on-chain state via Stellar RPC; the registry
+contract itself only exposes `get(did_id) -> Option<DidRecord>` (§4.1).
+
+#### 5.7.1 Resolution Algorithm
+
+1. **Validate syntax.** If `did` does not match the §2.2 regex → fail with
+   `didResolutionMetadata.error = "invalidDid"`.
+2. **Decode** the method-specific id (base32 → 16 bytes, §2.3).
+3. **Read** `get(did_id)` from the registry. If it returns `None` → fail with
+   `didResolutionMetadata.error = "notFound"`.
+4. **Deactivated.** If `DidRecord.deactivated == true`, return the tombstone DID
+   Document (Annex A.3) with `didDocumentMetadata.deactivated = true`. This is a
+   successful resolution (no `error`), but an HTTP binding MUST map it to `410 Gone`.
+5. **Construct** the DID Document per §5.1–§5.6 and populate the metadata below.
+
+#### 5.7.2 `didResolutionMetadata`
+
+| Property | Value |
+|---|---|
+| `contentType` | `application/did+ld+json` for `resolve`; the negotiated representation for `resolveRepresentation`. |
+| `error` | Present only on failure. One of `invalidDid`, `notFound`, `representationNotSupported`, `methodNotSupported`, `internalError`. |
+
+#### 5.7.3 `didDocumentMetadata`
+
+| Property | Source | Notes |
+|---|---|---|
+| `created` | `DidRecord.created_ledger` | The resolver maps the ledger sequence to its close time (ISO 8601 UTC) via Stellar RPC. |
+| `updated` | `DidRecord.updated_ledger` | Same mapping. Equals `created` until the first mutation. |
+| `versionId` | `DidRecord.version` | Expressed as a decimal string. |
+| `deactivated` | `DidRecord.deactivated` | Included only when `true` (MUST be `true` for a tombstone). |
+| `method.stellarAccount` | `DidRecord.controller` | Informational; the controller account is NOT a `controller` field on the document (§5.3). |
+
+#### 5.7.4 Error Model (HTTP binding)
+
+For resolvers exposed over HTTP, conditions map to status codes as follows:
+
+| Condition | `error` | HTTP |
+|---|---|---|
+| DID fails the §2.2 syntax regex | `invalidDid` | `400` |
+| DID is well-formed but was never registered | `notFound` | `404` |
+| DID is deactivated (tombstone) | *(none; `didDocumentMetadata.deactivated = true`)* | `410` |
+| `accept` requests an unsupported representation | `representationNotSupported` | `406` |
+| The DID is not a `did:stellar` DID | `methodNotSupported` | `501` |
+| Registry read / RPC failure | `internalError` | `500` |
+
+A `transfer_controller` (§4.4) does NOT change the resolved DID Document — it only
+updates `didDocumentMetadata.method.stellarAccount` and bumps `versionId`.
+
 ---
 
 ## 6. Proof of Control
@@ -805,6 +859,7 @@ status-list endpoints.
 ## 11. References
 
 - [W3C Decentralized Identifiers (DIDs) v1.1](https://www.w3.org/TR/did-1.1/)
+- [W3C Decentralized Identifier Resolution (DID Resolution) v0.3](https://www.w3.org/TR/did-resolution/)
 - [W3C Verifiable Credentials Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/)
 - [W3C DID Specification Registries](https://www.w3.org/TR/did-spec-registries/)
 - [W3C Multikey](https://www.w3.org/TR/cid-1.0/#multikey)

--- a/docs/did-spec/did-stellar-v0.1.md
+++ b/docs/did-spec/did-stellar-v0.1.md
@@ -482,7 +482,7 @@ The verifier executes the following steps in order:
 
 ## 7. Security Considerations
 
-This section is REQUIRED by W3C DID Core 1.1 §7.3.
+This section satisfies the requirements of [W3C DID Core 1.1 §7.3 (Security Requirements)](https://www.w3.org/TR/did-1.1/#security-requirements), which mandate documenting the RFC 3552 attack forms (§7.9), operation integrity and authentication, the unique-assignment policy (§7.10), and the verifiable-data-registry trust assumptions (§7.11).
 
 ### 7.1 Residue Attacks
 
@@ -528,11 +528,69 @@ The registry contract is deployed as immutable in v0.1. If a future version requ
 
 `service_endpoint` and `metadata_uri` only accept `https://` URLs. This prevents off-chain metadata from being served over unencrypted connections and reduces the risk of metadata-spoofing attacks.
 
+### 7.9 Attack Surface
+
+Per [W3C DID Core 1.1 §7.3](https://www.w3.org/TR/did-1.1/#security-requirements) and
+[RFC 3552](https://www.rfc-editor.org/rfc/rfc3552), the following attack forms are
+documented for the DID operations of §4 (`register` / `update` / `transfer_controller` /
+`deactivate` / `get`) and the proof of control of §6:
+
+| Attack | Treatment |
+|---|---|
+| **Eavesdropping** | All on-chain data is public by design (§8.2); there is no confidential payload to eavesdrop. The proof-of-control challenge and signature are not secret — reuse is prevented by `nonce` + `timestamp` + `domain` (§7.5), not by confidentiality. |
+| **Replay** | See §7.5. On-chain mutations are protected by optimistic concurrency (`expected_version`, §4.3); proof of control by a single-use `nonce` and a ±5-minute `timestamp` window. |
+| **Message insertion** | Every mutation requires `controller.require_auth()` (§4.2), verified by the Soroban host. An attacker cannot insert a forged operation without the controller signature. |
+| **Message deletion** | Confirmed ledger entries are immutable; a `DidRecord` cannot be deleted from the chain. Suppressing *submission* of a transaction is a network-level censorship concern outside this method. |
+| **Message modification** | Stellar transaction signatures and ledger integrity reject in-flight modification: a modified transaction fails signature verification and is not applied. |
+| **Denial of service** | User-controlled input lengths are capped (§3.3) to bound CPU and storage; storage rent / TTL is managed (§7.6). Operations are O(1) over fixed-size records — there is no unbounded work. Network-level flooding is a Stellar-layer concern; submitters bear the fee burden. |
+| **Amplification** | Operations have bounded, fixed-size effects (no recursion, unbounded loops, or reflection). No input produces a disproportionately large on-chain effect. |
+| **Man-in-the-middle** | On-chain operations are signed, so a MITM cannot forge a controller-authorized mutation. For *resolution*, a MITM on the RPC path could return a stale or forged DID Document — resolvers MUST read from a trusted Stellar RPC endpoint over TLS, or validate ledger entries directly (§7.11). The proof-of-control `domain` binding prevents cross-site relay of a valid proof. |
+
+Other known attack forms (e.g., social engineering of the controller account, supply-chain
+compromise of an off-chain resolver) are residual risks discussed in §7.11.
+
+### 7.10 Operation Integrity, Authentication, and Unique Assignment
+
+**Integrity and update authentication.** Every operation in §4.2 is integrity-protected
+and update-authenticated by the Stellar ledger: the `controller` account authorizes each
+mutation via `require_auth()`, and confirmed entries are immutable. The DID Document is
+**not** independently signed — its integrity derives from the verifiable data registry
+(the ledger), not from a document-level proof. Consumers obtain integrity by reading the
+`DidRecord` from the registry (§5.7), not by checking a signature on the document.
+
+**Cryptographically protected data.** On-chain `DidRecord` fields are
+**integrity-protected** (Stellar consensus + transaction signatures) but **not
+confidential** — all are public. Published verification keys are public by definition.
+Proof-of-control messages are protected by Ed25519 signatures (integrity and origin
+authentication only; no confidentiality). Private keys — the controller account key and
+the `authentication` / `assertion_method` keys — are secret and MUST be held off-chain.
+
+**Unique assignment.** A `did_id` is a 128-bit value; `register` fails with
+`DidAlreadyExists` if the id already exists (§4.4), giving first-writer-wins uniqueness.
+Combined with the 128-bit space, collision or squatting of a specific id is
+cryptographically negligible. Uniqueness is of the *identifier* only; the method binds a
+`did_id` to no external real-world identity.
+
+### 7.11 Verifiable Data Registry Trust
+
+Resolution and verification read on-chain state through Stellar RPC, and inherit the trust
+assumptions of that data source:
+
+- A **full node** validates ledger state independently; a **light/thin client** trusts the
+  RPC provider's view. Implementations SHOULD use endpoints they trust over TLS to prevent
+  tampering of the RPC response (§7.9, MITM).
+- The method's security ultimately rests on the integrity of Stellar consensus. A
+  successful attack on consensus would compromise the registry; this residual risk is
+  inherited from the underlying DLT and is out of scope for mitigation by this method.
+- Off-chain components (resolver, verifier, proof-of-control implementation) are additional
+  residual-risk surfaces: an incorrect canonicalization, signature check, or status lookup
+  in those components can defeat the on-chain guarantees.
+
 ---
 
 ## 8. Privacy Considerations
 
-This section is REQUIRED by W3C DID Core 1.1 §7.4.
+This section satisfies the requirements of [W3C DID Core 1.1 §7.4 (Privacy Requirements)](https://www.w3.org/TR/did-1.1/#privacy-requirements), which mandate discussing each applicable [RFC 6973 §5](https://www.rfc-editor.org/rfc/rfc6973#section-5) privacy category in a method-specific manner (§8.6).
 
 ### 8.1 No PII On-Chain
 
@@ -553,6 +611,24 @@ The `DidRecord.controller` field exposes the controller Stellar account. This da
 ### 8.5 Right to Be Forgotten
 
 Deactivation (`deactivate`) removes all cryptographic material from the on-chain record. However, blockchain history is permanent: previous versions of the `DidRecord` may be visible in historical ledger data or indexers. `did:stellar` does not provide a mechanism for retroactive erasure of on-chain history.
+
+### 8.6 RFC 6973 Threat Coverage
+
+Per [W3C DID Core 1.1 §7.4](https://www.w3.org/TR/did-1.1/#privacy-requirements), each
+applicable [RFC 6973 §5](https://www.rfc-editor.org/rfc/rfc6973#section-5) category is
+addressed for this method:
+
+| Category | Method-specific treatment |
+|---|---|
+| **Surveillance** | All DID operations are public-ledger transactions; an observer can monitor the full mutation history of any DID. Subjects requiring unobservable updates SHOULD NOT use a public-ledger method for those DIDs. |
+| **Stored data compromise** | The registry stores no PII, passwords, or private keys (§8.1), so compromise of stored data exposes nothing not already public. Off-chain metadata referenced via `metadata_uri` is the integrator's responsibility to protect. |
+| **Unsolicited traffic** | A `service_endpoint` in the DID Document is publicly visible and MAY receive unsolicited traffic. Subjects SHOULD publish only endpoints intended to be public. |
+| **Misattribution** | The DID is opaque with no inherent link to a person; control is provable only via the `authentication` keys (§6), preventing false attribution of control. |
+| **Correlation** | See §8.3. Reuse of one DID across contexts enables linkage; subjects MAY use distinct DIDs per context. |
+| **Identification** | The `did_id` carries no PII, but `DidRecord.controller` links the DID to a specific Stellar account (§8.4), enabling identification of the controller. |
+| **Secondary use** | All on-chain data is public and permanent and MAY be reused beyond its original intent. Subjects MUST assume any published data is permanently reusable. |
+| **Disclosure** | All `DidRecord` fields — keys, services, controller — are publicly disclosed on the ledger (§8.2). |
+| **Exclusion** | A public ledger offers no access control: a subject cannot prevent third parties from observing or recording their on-chain data, nor be notified of such access. |
 
 ---
 

--- a/docs/did-spec/test-vectors/vectors.json
+++ b/docs/did-spec/test-vectors/vectors.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "did:stellar v0.1 normative test vectors. All vectors use network=testnet. Vectors 1-4 exercise on-chain contract behavior. Vectors 5-6 exercise the off-chain proof of control protocol. The controller field uses a representative Stellar StrKey-formatted address; conformance test runs SHOULD substitute a real funded testnet keypair.",
+  "_comment": "did:stellar v0.1 normative test vectors. All vectors use network=testnet. Vectors 1-4 exercise on-chain contract behavior (register / full record / tombstone / version conflict). Vectors 5-6 exercise the off-chain proof of control protocol (challenge_jcs_hex is pinned; signatures await the reference implementation). Vector 7 exercises multi-key index numbering (#auth-2). Vectors 8-9 exercise DID Resolution errors (notFound / invalidDid) per section 5.7. The controller field uses a representative Stellar StrKey-formatted address; conformance test runs SHOULD substitute a real funded testnet keypair.",
   "method": "did:stellar",
   "spec_version": "0.1",
   "vectors": [
@@ -187,7 +187,7 @@
     {
       "id": "vector-5",
       "description": "Valid proof of control: fixed challenge + fixed Ed25519 key → signature verifies.",
-      "_note": "Exact signature computed by the reference implementation. Values below will be populated when the TypeScript reference implementation is complete.",
+      "_note": "challenge_jcs_hex is the canonical RFC 8785 (JCS) byte form, pinned here so every implementation MUST canonicalize to exactly these bytes before signing. auth_key_private_hex and signature_base64url still require the reference implementation: the private key for the published auth key is not disclosed.",
       "input": {
         "did": "did:stellar:testnet:aaaqeayeaudaocajbifqydiob4",
         "auth_key_public_multibase": "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doY",
@@ -198,7 +198,7 @@
           "nonce": "5f9b2a1c0d3e4f6789012345abcdef01",
           "timestamp": "2026-04-26T12:34:56Z"
         },
-        "challenge_jcs_hex": "TODO: JCS-canonicalized challenge bytes (reference implementation)",
+        "challenge_jcs_hex": "7b22646964223a226469643a7374656c6c61723a746573746e65743a6161617165617965617564616f63616a626966717964696f6234222c22646f6d61696e223a2276657269666965722e6578616d706c652e636f6d222c226e6f6e6365223a223566396232613163306433653466363738393031323334356162636465663031222c2274696d657374616d70223a22323032362d30342d32365431323a33343a35365a227d",
         "signature_base64url": "TODO: Ed25519 signature base64url (reference implementation)"
       },
       "expected": {
@@ -217,12 +217,98 @@
           "nonce": "5f9b2a1c0d3e4f6789012345abcdef01",
           "timestamp": "2020-01-01T00:00:00Z"
         },
+        "challenge_jcs_hex": "7b22646964223a226469643a7374656c6c61723a746573746e65743a6161617165617965617564616f63616a626966717964696f6234222c22646f6d61696e223a2276657269666965722e6578616d706c652e636f6d222c226e6f6e6365223a223566396232613163306433653466363738393031323334356162636465663031222c2274696d657374616d70223a22323032302d30312d30315430303a30303a30305a227d",
         "signature_base64url": "TODO: any signature (irrelevant; timestamp check fires first)"
       },
       "expected": {
         "result": "invalid",
         "verification_passed": false,
         "failure_reason": "timestamp out of ±5 minute window"
+      }
+    },
+    {
+      "id": "vector-7",
+      "description": "Multiple authentication keys: index numbering produces #auth-1 and #auth-2, both referenced from authentication.",
+      "input": {
+        "did_id_bytes_hex": "101112131415161718191a1b1c1d1e1f",
+        "did_id_base32": "caireeyuculbogazdinryhi6d4",
+        "did": "did:stellar:testnet:caireeyuculbogazdinryhi6d4",
+        "network": "testnet",
+        "controller": "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZMJV4P6W2WL6WXHNTQZM2",
+        "record": {
+          "authentication": [
+            { "public_key_multibase": "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doY" },
+            { "public_key_multibase": "z6Mkff3F4VMDGbMbMtgRyXMrgr7qyxaKsPo7QEPQ2AkNrx2X" }
+          ],
+          "assertion_method": [],
+          "key_agreement": [],
+          "services": [],
+          "metadata_uri": null,
+          "metadata_hash": null,
+          "version": 1,
+          "created_ledger": 2000,
+          "updated_ledger": 2000,
+          "deactivated": false
+        }
+      },
+      "expected": {
+        "did_document": {
+          "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1"
+          ],
+          "id": "did:stellar:testnet:caireeyuculbogazdinryhi6d4",
+          "verificationMethod": [
+            {
+              "id": "did:stellar:testnet:caireeyuculbogazdinryhi6d4#auth-1",
+              "type": "Multikey",
+              "controller": "did:stellar:testnet:caireeyuculbogazdinryhi6d4",
+              "publicKeyMultibase": "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doY"
+            },
+            {
+              "id": "did:stellar:testnet:caireeyuculbogazdinryhi6d4#auth-2",
+              "type": "Multikey",
+              "controller": "did:stellar:testnet:caireeyuculbogazdinryhi6d4",
+              "publicKeyMultibase": "z6Mkff3F4VMDGbMbMtgRyXMrgr7qyxaKsPo7QEPQ2AkNrx2X"
+            }
+          ],
+          "authentication": [
+            "did:stellar:testnet:caireeyuculbogazdinryhi6d4#auth-1",
+            "did:stellar:testnet:caireeyuculbogazdinryhi6d4#auth-2"
+          ],
+          "assertionMethod": [],
+          "keyAgreement": [],
+          "service": []
+        },
+        "did_document_metadata": {
+          "versionId": "1",
+          "deactivated": false
+        }
+      }
+    },
+    {
+      "id": "vector-8",
+      "description": "Resolution of a well-formed but unregistered DID: get(did_id) returns None.",
+      "input": {
+        "did": "did:stellar:testnet:ucq2fi5euwtkpkfjvkv2zlnov4",
+        "registry_get": null
+      },
+      "expected": {
+        "http_status": 404,
+        "did_resolution_metadata": { "error": "notFound" },
+        "did_document": null
+      }
+    },
+    {
+      "id": "vector-9",
+      "description": "Resolution of a syntactically invalid DID: fails the section 2.2 regex (id too short and uppercase).",
+      "input": {
+        "did": "did:stellar:testnet:TOOSHORT"
+      },
+      "expected": {
+        "http_status": 400,
+        "did_resolution_metadata": { "error": "invalidDid" },
+        "did_document": null
       }
     }
   ]


### PR DESCRIPTION
Closes the W3C-conformance gaps in the `did:stellar` spec found in the contract/spec audit. **No contract changes** — all spec / convention / test-vector / documentation only.

## 1. Credential Status — `StellarStatusRegistryEntry` (Annex B.4)

The `vc-vault` tracks per-VC status on-chain (`verify_vc`), but a third-party verifier had no standard way to discover it. Adds a [W3C VC Data Model 2.0 §4.10](https://www.w3.org/TR/vc-data-model-2.0/#status) `credentialStatus` method:

```json
"credentialStatus": {
  "type": "StellarStatusRegistryEntry",
  "statusPurpose": "revocation",
  "network": "testnet",
  "statusContract": "C...",
  "vcId": "vc-123"
}
```

The verifier resolves it via a read-only `verify_vc(vcId)` RPC call (`Valid`/`Revoked`/`Invalid`). Custom status types are explicitly permitted by §4.10, and the read-only ledger lookup never notifies the issuer — satisfying the §4.10 privacy MUST against holder tracking.

## 2. DID Resolution (§5.7)

The spec defined DID Document *construction* (§5) but not *resolution* per [W3C DID Resolution v0.3](https://www.w3.org/TR/did-resolution/). Adds §5.7:

- `resolve()` three-tuple result + resolution algorithm
- `didResolutionMetadata` (`contentType`, `error`)
- `didDocumentMetadata` (`created`/`updated`/`versionId`/`deactivated` mapped from `DidRecord` ledger fields)
- Error model with HTTP bindings (`invalidDid` 400, `notFound` 404, deactivated 410, `representationNotSupported` 406, …)

## 3. Test vectors (6 → 9)

- Pin `challenge_jcs_hex` (canonical RFC 8785 bytes) in vectors 5–6 so every implementation MUST canonicalize to exactly these bytes before signing. (Ed25519 signatures still await the off-chain reference implementation.)
- **Vector 7** — multi-key: exercises `#auth-2` index numbering.
- **Vectors 8–9** — DID Resolution errors (`notFound` 404 / `invalidDid` 400) per §5.7.

## 4. Security & Privacy per DID Core 1.1 §7.3 / §7.4

[DID Core 1.1 §7.3](https://www.w3.org/TR/did-1.1/#security-requirements) mandates documenting the RFC 3552 attack forms; [§7.4](https://www.w3.org/TR/did-1.1/#privacy-requirements) mandates discussing each applicable RFC 6973 §5 privacy category. The spec previously covered only replay (security) and correlation/disclosure (privacy).

- **§7.9 Attack Surface** — all 8 mandated attack forms (eavesdropping, replay, message insertion/deletion/modification, DoS, amplification, MITM) with method-specific treatment.
- **§7.10** — operation integrity + authentication, unique assignment (`DidAlreadyExists` + 128-bit id), and which data is cryptographically protected.
- **§7.11** — verifiable-data-registry / DLT trust assumptions and residual risk.
- **§8.6** — all 9 RFC 6973 categories mapped (surveillance, stored-data compromise, unsolicited traffic, misattribution, correlation, identification, secondary use, disclosure, exclusion).
- Fix the §7/§8 citations to the normative §7.3/§7.4 section titles.

---

The resolver/verifier that consume these conventions, and the real signatures for vectors 5–6, remain off-chain implementation work (out of scope for this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Specified DID Resolution process including resolver contract behavior, validation, and document construction requirements.
  * Specified Credential Revocation Status with on-chain verification procedures and privacy guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
