### PR TITLE
fix: low-severity defensive hardening (vault + factory)

### DIFF
--- a/contracts/vc-vault-factory/src/errors.rs
+++ b/contracts/vc-vault-factory/src/errors.rs
@@ -18,4 +18,6 @@ pub enum FactoryError {
     FeeNotConfigured = 5,
     /// Custom fee expiry timestamp is not in the future.
     ExpiryInPast = 6,
+    /// VaultMeta is missing (constructor never ran or state lost).
+    NotInitialized = 7,
 }

--- a/contracts/vc-vault-factory/src/storage.rs
+++ b/contracts/vc-vault-factory/src/storage.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracttype, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contracttype, panic_with_error, Address, BytesN, Env, Symbol};
+
+use crate::errors::FactoryError;
 
 const ONE_DAY_LEDGERS: u32 = 17_280; // ~5s per ledger
 
@@ -60,7 +62,7 @@ pub fn get_vault_init_meta(e: &Env) -> VaultInitMeta {
     e.storage()
         .instance()
         .get::<Symbol, VaultInitMeta>(&Symbol::new(e, "VaultMeta"))
-        .unwrap()
+        .unwrap_or_else(|| panic_with_error!(e, FactoryError::NotInitialized))
 }
 
 pub fn set_deployed(e: &Env, vault_address: &Address) {

--- a/contracts/vc-vault/src/constants.rs
+++ b/contracts/vc-vault/src/constants.rs
@@ -49,3 +49,6 @@ pub const MAX_DID_URI_LEN: u32 = 256;
 pub const MAX_ISSUER_DID_LEN: u32 = 256;
 /// Maximum bytes for revocation `date` strings (ISO 8601).
 pub const MAX_DATE_LEN: u32 = 64;
+/// Maximum number of issuers a vault may hold in its denied (block) list.
+/// Bounds storage growth; the list only grows via admin `deny_issuer` calls.
+pub const MAX_DENIED_ISSUERS: u32 = 1_000;

--- a/contracts/vc-vault/src/storage/credential.rs
+++ b/contracts/vc-vault/src/storage/credential.rs
@@ -125,9 +125,16 @@ pub fn remove_vc_from_index(e: &Env, vc_id: &String) {
     }
     let last = count - 1;
     if position != last {
-        if let Some(last_id) = read_vc_id_at(e, last) {
-            write_vc_id_at(e, position, &last_id);
-            write_vc_position(e, &last_id, position);
+        // Normal swap-and-pop moves the last entry into the freed slot.
+        // Defensive: if the last slot is somehow missing (corrupt state), clear
+        // the freed slot instead of leaving the removed id there — otherwise it
+        // becomes a ghost index entry. Never panic on the missing slot.
+        match read_vc_id_at(e, last) {
+            Some(last_id) => {
+                write_vc_id_at(e, position, &last_id);
+                write_vc_position(e, &last_id, position);
+            }
+            None => remove_vc_id_at(e, position),
         }
     }
     remove_vc_id_at(e, last);

--- a/contracts/vc-vault/src/storage/credential.rs
+++ b/contracts/vc-vault/src/storage/credential.rs
@@ -125,9 +125,10 @@ pub fn remove_vc_from_index(e: &Env, vc_id: &String) {
     }
     let last = count - 1;
     if position != last {
-        let last_id = read_vc_id_at(e, last).unwrap();
-        write_vc_id_at(e, position, &last_id);
-        write_vc_position(e, &last_id, position);
+        if let Some(last_id) = read_vc_id_at(e, last) {
+            write_vc_id_at(e, position, &last_id);
+            write_vc_position(e, &last_id, position);
+        }
     }
     remove_vc_id_at(e, last);
     remove_vc_position(e, vc_id);

--- a/contracts/vc-vault/src/storage/issuer.rs
+++ b/contracts/vc-vault/src/storage/issuer.rs
@@ -1,8 +1,9 @@
 //! Denied issuer index storage. O(1) operations via swap-and-pop.
 
-use crate::constants::{PERSISTENT_TTL_EXTEND_TO, PERSISTENT_TTL_THRESHOLD};
+use crate::constants::{MAX_DENIED_ISSUERS, PERSISTENT_TTL_EXTEND_TO, PERSISTENT_TTL_THRESHOLD};
+use crate::error::ContractError;
 use super::VcVaultDataKey;
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{panic_with_error, Address, Env};
 
 // --- Denied issuer index ---
 
@@ -84,6 +85,9 @@ pub fn append_denied_issuer_to_index(e: &Env, issuer: &Address) {
         return;
     }
     let count = read_denied_issuer_count(e);
+    if count >= MAX_DENIED_ISSUERS {
+        panic_with_error!(e, ContractError::IssuerListTooLong);
+    }
     write_denied_issuer_at(e, count, issuer);
     write_denied_issuer_position(e, issuer, count);
     write_denied_issuer_count(e, count + 1);
@@ -101,9 +105,12 @@ pub fn remove_denied_issuer_from_index(e: &Env, issuer: &Address) {
     }
     let last = count - 1;
     if position != last {
-        let last_addr = read_denied_issuer_at(e, last).unwrap();
-        write_denied_issuer_at(e, position, &last_addr);
-        write_denied_issuer_position(e, &last_addr, position);
+        // Defensive: if the last slot is missing, skip the swap rather than
+        // panicking on unwrap(). The slot is still cleared and count decremented.
+        if let Some(last_addr) = read_denied_issuer_at(e, last) {
+            write_denied_issuer_at(e, position, &last_addr);
+            write_denied_issuer_position(e, &last_addr, position);
+        }
     }
     remove_denied_issuer_at(e, last);
     remove_denied_issuer_position(e, issuer);

--- a/contracts/vc-vault/src/storage/issuer.rs
+++ b/contracts/vc-vault/src/storage/issuer.rs
@@ -105,11 +105,16 @@ pub fn remove_denied_issuer_from_index(e: &Env, issuer: &Address) {
     }
     let last = count - 1;
     if position != last {
-        // Defensive: if the last slot is missing, skip the swap rather than
-        // panicking on unwrap(). The slot is still cleared and count decremented.
-        if let Some(last_addr) = read_denied_issuer_at(e, last) {
-            write_denied_issuer_at(e, position, &last_addr);
-            write_denied_issuer_position(e, &last_addr, position);
+        // Normal swap-and-pop moves the last entry into the freed slot.
+        // Defensive: if the last slot is somehow missing (corrupt state), clear
+        // the freed slot instead of leaving the removed issuer there — otherwise
+        // it becomes a ghost index entry. Never panic on the missing slot.
+        match read_denied_issuer_at(e, last) {
+            Some(last_addr) => {
+                write_denied_issuer_at(e, position, &last_addr);
+                write_denied_issuer_position(e, &last_addr, position);
+            }
+            None => remove_denied_issuer_at(e, position),
         }
     }
     remove_denied_issuer_at(e, last);


### PR DESCRIPTION
## Summary

Defensive hardening of low-severity findings from the security review. No behavior change in normal flows — these remove panic paths in corrupt/edge states and bound an unbounded list.

- **Vault index removal no longer panics on a missing last slot** (findings #6, #14): `remove_vc_from_index` and `remove_denied_issuer_from_index` used `.unwrap()` on the last index entry. If that entry were ever missing, the call panicked. Now the swap is skipped gracefully and the count is still decremented.
- **Denied-issuer list is now bounded** (finding #15): `append_denied_issuer_to_index` caps the list at `MAX_DENIED_ISSUERS = 1_000` (reuses `IssuerListTooLong`). The list only grows via admin `deny_issuer`, but this bounds storage growth.
- **Factory returns a controlled error instead of panicking on missing `VaultMeta`** (finding #9): `get_vault_init_meta` now fails with `FactoryError::NotInitialized` rather than `.unwrap()`.

These are the LOW/INFO defensive items; the corresponding states are not reachable through normal contract flows, so there are no new unit tests (the fixes harden against corrupt/edge states the contract doesn't itself produce). Existing suite stays green.

## Findings covered

| Finding | Fix |
|---|---|
| remove_vc_from_index unwrap | graceful None handling |
| remove_denied_issuer_from_index unwrap | graceful None handling |
| denied list unbounded | cap at 1000 |
| factory get_vault_init_meta unwrap | controlled NotInitialized error |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when vault metadata is missing, with clearer error reporting (new error code).
  * Enhanced robustness of vault credential and issuer removal operations.
  * Enforced maximum limit of 1,000 entries for denied issuer lists to prevent unbounded growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->