### PR TITLE
fix: reject duplicate service id_suffix in DID registry

### DIFF
--- a/contracts/did-stellar-registry/src/contract.rs
+++ b/contracts/did-stellar-registry/src/contract.rs
@@ -324,9 +324,19 @@ fn validate_record(e: &Env, record: &DidRecord) {
     validate_keys_cross_duplicates(e, &record.assertion_method, &record.key_agreement);
 
     // --- Services ---
+    // Each service is validated individually, and `id_suffix` must be unique
+    // across all services — duplicates would resolve to the same
+    // `{did}#service-{id_suffix}` fragment, making the DID Document ambiguous.
+    // Pairwise comparison is bounded because `services.len() <= MAX_SERVICE_COUNT` (3).
     for i in 0..record.services.len() {
         let s: DidService = record.services.get_unchecked(i);
         validate_service(e, &s);
+        for j in (i + 1)..record.services.len() {
+            let other: DidService = record.services.get_unchecked(j);
+            if s.id_suffix == other.id_suffix {
+                panic_with_error!(e, RegistryError::DuplicateServiceId);
+            }
+        }
     }
 
     // --- Optional metadata URI ---

--- a/contracts/did-stellar-registry/src/errors.rs
+++ b/contracts/did-stellar-registry/src/errors.rs
@@ -50,4 +50,7 @@ pub enum RegistryError {
     /// `metadata_hash` is `Some` but `metadata_uri` is `None`. An integrity
     /// hash without a corresponding URI is orphaned and meaningless.
     MetadataInconsistent = 20,
+    /// Two services share the same `id_suffix`, which would produce duplicate
+    /// `{did}#service-{id_suffix}` fragments in the resolved DID Document.
+    DuplicateServiceId = 21,
 }

--- a/contracts/did-stellar-registry/src/test.rs
+++ b/contracts/did-stellar-registry/src/test.rs
@@ -445,6 +445,46 @@ fn test_boundary_service_id_underscore() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #21)")] // DuplicateServiceId
+fn test_boundary_duplicate_service_id() {
+    let (env, controller, did_id, _id, client) = setup();
+    let mut r = minimal_record(&env, &controller);
+    let mut svcs = empty_services(&env);
+    svcs.push_back(DidService {
+        id_suffix: s(&env, "issuer"),
+        service_type: s(&env, "LinkedDomains"),
+        service_endpoint: s(&env, "https://a.example.com"),
+    });
+    svcs.push_back(DidService {
+        id_suffix: s(&env, "issuer"),
+        service_type: s(&env, "LinkedDomains"),
+        service_endpoint: s(&env, "https://b.example.com"),
+    });
+    r.services = svcs;
+    client.register(&did_id, &r);
+}
+
+#[test]
+fn test_distinct_service_ids_ok() {
+    let (env, controller, did_id, _id, client) = setup();
+    let mut r = minimal_record(&env, &controller);
+    let mut svcs = empty_services(&env);
+    svcs.push_back(DidService {
+        id_suffix: s(&env, "issuer"),
+        service_type: s(&env, "LinkedDomains"),
+        service_endpoint: s(&env, "https://a.example.com"),
+    });
+    svcs.push_back(DidService {
+        id_suffix: s(&env, "status"),
+        service_type: s(&env, "LinkedDomains"),
+        service_endpoint: s(&env, "https://b.example.com"),
+    });
+    r.services = svcs;
+    client.register(&did_id, &r);
+    assert_eq!(client.get(&did_id).unwrap().services.len(), 2);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #12)")] // ServiceTypeTooLong
 fn test_boundary_service_type_too_long() {
     let (env, controller, did_id, _id, client) = setup();


### PR DESCRIPTION
## Summary

`validate_record` in `did-stellar-registry` validated each service individually but never checked that `id_suffix` was unique across the `services` array. Two services sharing an `id_suffix` resolve to the same `{did}#service-{id_suffix}` fragment, producing an ambiguous DID Document (different resolvers may pick the first/last match → endpoint confusion).

This adds a uniqueness check: duplicate `id_suffix` values are now rejected with a new `DuplicateServiceId` error. The comparison is pairwise and bounded by `MAX_SERVICE_COUNT` (3), so it is cheap.

(Security review finding: duplicate service IDs allow ambiguous DID documents.)

## Changes

- New error `RegistryError::DuplicateServiceId = 21`.
- `validate_record` rejects services with duplicate `id_suffix`.