### PR TITLE
chore: remove dead VC parent-link code

### DIFF
--- a/contracts/vc-vault/src/error.rs
+++ b/contracts/vc-vault/src/error.rs
@@ -28,8 +28,6 @@ pub enum ContractError {
     VCAlreadyExists = 12,
     /// accept_contract_admin called but no admin nomination is pending.
     NoPendingAdmin = 13,
-    /// The parent VC does not exist or has been revoked.
-    ParentVCInvalid = 14,
     /// Vault has reached the maximum number of active VCs.
     VaultFull = 15,
     /// Pagination `limit` exceeds `MAX_LIST_LIMIT`.

--- a/contracts/vc-vault/src/storage/credential.rs
+++ b/contracts/vc-vault/src/storage/credential.rs
@@ -1,4 +1,4 @@
-//! VC payload, O(1) index, parent links, and status storage.
+//! VC payload, O(1) index, and status storage.
 
 use crate::constants::{PERSISTENT_TTL_EXTEND_TO, PERSISTENT_TTL_THRESHOLD};
 use crate::error::ContractError;
@@ -132,36 +132,6 @@ pub fn remove_vc_from_index(e: &Env, vc_id: &String) {
     remove_vc_id_at(e, last);
     remove_vc_position(e, vc_id);
     write_vc_count(e, last);
-}
-
-// --- VC parent links ---
-
-pub fn write_vc_parent(e: &Env, vc_id: &String, parent_vc_id: &String) {
-    let key = VcVaultDataKey::VCParent(vc_id.clone());
-    e.storage()
-        .persistent()
-        .set(&key, parent_vc_id);
-    e.storage()
-        .persistent()
-        .extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
-}
-
-pub fn read_vc_parent(e: &Env, vc_id: &String) -> Option<String> {
-    e.storage()
-        .persistent()
-        .get(&VcVaultDataKey::VCParent(vc_id.clone()))
-}
-
-pub fn has_vc_parent(e: &Env, vc_id: &String) -> bool {
-    e.storage()
-        .persistent()
-        .has(&VcVaultDataKey::VCParent(vc_id.clone()))
-}
-
-pub fn remove_vc_parent(e: &Env, vc_id: &String) {
-    e.storage()
-        .persistent()
-        .remove(&VcVaultDataKey::VCParent(vc_id.clone()));
 }
 
 // --- VC status ---

--- a/contracts/vc-vault/src/storage/mod.rs
+++ b/contracts/vc-vault/src/storage/mod.rs
@@ -51,6 +51,4 @@ pub enum VcVaultDataKey {
     /// Position of a given vc_id in the index.
     VaultVCPosition(String),
     VCStatus(String),
-    VCParent(String),
-
 }


### PR DESCRIPTION
## Summary

Removes leftover dead code from a `parent`/`linked-VC` feature that no longer exists in the contract. None of it had any callers (verified across `src/` and tests).

- `storage/credential.rs`: removed `write_vc_parent`, `read_vc_parent`, `has_vc_parent`, `remove_vc_parent`.
- `storage/mod.rs`: removed the `VCParent(String)` storage key.
- `error.rs`: removed the unused `ParentVCInvalid = 14` error variant.