### PR TITLE
style: clean clippy lints in did-stellar-registry

### DIFF
--- a/contracts/did-stellar-registry/src/contract.rs
+++ b/contracts/did-stellar-registry/src/contract.rs
@@ -297,7 +297,7 @@ fn require_version(e: &Env, expected: u32, current: u32) {
 fn validate_record(e: &Env, record: &DidRecord) {
     // --- Key counts ---
     let auth_len = record.authentication.len();
-    if auth_len < MIN_KEY_COUNT_AUTH || auth_len > MAX_KEY_COUNT_AUTH {
+    if !(MIN_KEY_COUNT_AUTH..=MAX_KEY_COUNT_AUTH).contains(&auth_len) {
         panic_with_error!(e, RegistryError::InvalidAuthKeyCount);
     }
     if record.assertion_method.len() > MAX_KEY_COUNT_ASSERT {
@@ -393,13 +393,13 @@ fn validate_service(e: &Env, s: &DidService) {
     if s.id_suffix.len() > MAX_SERVICE_ID_LEN {
         panic_with_error!(e, RegistryError::ServiceIdTooLong);
     }
-    if s.id_suffix.len() == 0 {
+    if s.id_suffix.is_empty() {
         panic_with_error!(e, RegistryError::ServiceIdInvalidFormat);
     }
     if !is_valid_id_suffix(&s.id_suffix) {
         panic_with_error!(e, RegistryError::ServiceIdInvalidFormat);
     }
-    if s.service_type.len() == 0 {
+    if s.service_type.is_empty() {
         panic_with_error!(e, RegistryError::ServiceTypeEmpty);
     }
     if s.service_type.len() > MAX_SERVICE_TYPE_LEN {

--- a/contracts/did-stellar-registry/src/test.rs
+++ b/contracts/did-stellar-registry/src/test.rs
@@ -10,8 +10,6 @@
 //!  - events (smoke check that mutations emit something)
 //!  - normative test vectors (matches `docs/did-spec/test-vectors/vectors.json`)
 
-#![cfg(test)]
-
 extern crate std;
 
 use crate::contract::{DidStellarRegistry, DidStellarRegistryClient};
@@ -111,7 +109,7 @@ fn test_register_basic() {
     let r = client.get(&did_id).unwrap();
     assert_eq!(r.controller, controller);
     assert_eq!(r.version, 1);
-    assert_eq!(r.deactivated, false);
+    assert!(!r.deactivated);
     assert_eq!(r.authentication.len(), 1);
     // created_ledger == updated_ledger right after register.
     assert_eq!(r.created_ledger, r.updated_ledger);
@@ -379,7 +377,7 @@ fn test_boundary_key_too_long() {
     let (env, controller, did_id, _id, client) = setup();
     let mut r = minimal_record(&env, &controller);
     // 129 chars > MAX_KEY_MULTIBASE_LEN (128).
-    let long: std::string::String = core::iter::repeat('x').take(129).collect();
+    let long: std::string::String = core::iter::repeat_n('x', 129).collect();
     let mut auth = empty_keys(&env);
     auth.push_back(DidKey {
         public_key_multibase: String::from_str(&env, &long),
@@ -450,7 +448,7 @@ fn test_boundary_service_type_too_long() {
     let (env, controller, did_id, _id, client) = setup();
     let mut r = minimal_record(&env, &controller);
     // 65 chars > MAX_SERVICE_TYPE_LEN (64).
-    let long: std::string::String = core::iter::repeat('x').take(65).collect();
+    let long: std::string::String = core::iter::repeat_n('x', 65).collect();
     let mut svcs = empty_services(&env);
     svcs.push_back(DidService {
         id_suffix: s(&env, "issuer"),
@@ -468,7 +466,7 @@ fn test_boundary_service_id_too_long() {
     let mut r = minimal_record(&env, &controller);
     // 33 chars > MAX_SERVICE_ID_LEN (32). Use only valid `[a-z]` so the
     // length check fires before the format check.
-    let long: std::string::String = core::iter::repeat('a').take(33).collect();
+    let long: std::string::String = core::iter::repeat_n('a', 33).collect();
     let mut svcs = empty_services(&env);
     svcs.push_back(DidService {
         id_suffix: String::from_str(&env, &long),
@@ -649,7 +647,7 @@ fn test_vector_1_minimal_did() {
 
     let stored = client.get(&did_id).unwrap();
     assert_eq!(stored.version, 1);
-    assert_eq!(stored.deactivated, false);
+    assert!(!stored.deactivated);
     assert_eq!(stored.authentication.len(), 1);
     assert_eq!(stored.assertion_method.len(), 0);
     assert_eq!(stored.key_agreement.len(), 0);
@@ -723,7 +721,7 @@ fn test_vector_3_deactivated_tombstone() {
 
     let r = client.get(&did_id).unwrap();
     // Tombstone state per spec §6.6.
-    assert_eq!(r.deactivated, true);
+    assert!(r.deactivated);
     assert_eq!(r.version, 2);
     assert_eq!(r.authentication.len(), 0);
     assert_eq!(r.assertion_method.len(), 0);
@@ -762,7 +760,7 @@ fn test_record_round_trip_via_intoval() {
     let env = Env::default();
     let controller = Address::generate(&env);
     let r = minimal_record(&env, &controller);
-    let _val: soroban_sdk::Val = (&r).into_val(&env);
+    let _val: soroban_sdk::Val = r.into_val(&env);
 }
 
 // --- contract admin (constructor + two-step transfer) ----------------------


### PR DESCRIPTION
## Summary

Clears the pre-existing clippy debt in `did-stellar-registry` so the crate passes `clippy -D warnings`. No behavior change — purely lint fixes (mostly applied via `cargo clippy --fix`).

- `manual_range_contains`: key-count bound check rewritten with `RangeInclusive::contains`.
- `len_zero`: `len() == 0` → `is_empty()` in service validation.
- `bool_assert_comparison`: `assert_eq!(x, true/false)` → `assert!(x)` / `assert!(!x)` in tests.
- `manual_str_repeat` / `manual_repeat_n`: long-string test builders → `str::repeat`.
- `needless_borrow`: dropped a redundant `&`.
- `duplicated_attributes`: removed the redundant inner `#![cfg(test)]` (the module is already `#[cfg(test)]`-gated in `lib.rs`).